### PR TITLE
Disable About Us Navigation and Update Contact Details

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -27,24 +27,24 @@ const contactMethods = [
     icon: Mail,
     title: 'Email Us',
     description: 'Send us an email anytime',
-    primary: 'support@echno.com',
-    secondary: 'sales@echno.com',
+    primary: 'support@echnoai.com',
+    secondary: 'sales@echnoai.com',
     color: 'blue',
   },
   {
     icon: Phone,
     title: 'Call Us',
-    description: 'Mon-Fri from 9am to 6pm EST',
-    primary: '+1 (555) 123-4567',
-    secondary: '+1 (555) 987-6543',
+    description: 'Mon-Fri from 9am to 6pm IST',
+    primary: '+91 85900 40842',
+    secondary: '',
     color: 'green',
   },
   {
     icon: MapPin,
     title: 'Visit Us',
     description: 'Come say hello at our office',
-    primary: '123 Business Avenue',
-    secondary: 'San Francisco, CA 94107',
+    primary: 'Alappuzha',
+    secondary: 'Perumbavoor, Ernakulam, Kerala, India',
     color: 'purple',
   },
   {
@@ -80,22 +80,16 @@ const supportOptions = [
 
 const offices = [
   {
-    city: 'San Francisco',
-    country: 'United States',
-    address: '123 Business Avenue, San Francisco, CA 94107',
-    phone: '+1 (555) 123-4567',
+    city: 'Alappuzha',
+    country: 'India',
+    address: 'Chettikulangara, Mavelikkara, Kerala 690106',
+    phone: '+91 85900 40842',
   },
   {
-    city: 'New York',
-    country: 'United States',
-    address: '456 Innovation Street, New York, NY 10001',
-    phone: '+1 (555) 234-5678',
-  },
-  {
-    city: 'London',
-    country: 'United Kingdom',
-    address: '789 Tech Lane, London, EC1A 1BB',
-    phone: '+44 20 1234 5678',
+    city: 'Ernakulam',
+    country: 'India',
+    address: 'Perumbavoor, Ernakulam, Kerala',
+    phone: '+91 85900 40842',
   },
 ];
 
@@ -513,11 +507,11 @@ export default function ContactPage() {
                 <div className="space-y-2 text-sm">
                   <div className="flex justify-between text-zinc-600 dark:text-zinc-400">
                     <span>Monday - Friday</span>
-                    <span>9:00 AM - 6:00 PM EST</span>
+                    <span>9:00 AM - 6:00 PM IST</span>
                   </div>
                   <div className="flex justify-between text-zinc-600 dark:text-zinc-400">
                     <span>Saturday</span>
-                    <span>10:00 AM - 2:00 PM EST</span>
+                    <span>10:00 AM - 2:00 PM IST</span>
                   </div>
                   <div className="flex justify-between text-zinc-600 dark:text-zinc-400">
                     <span>Sunday</span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,7 +40,7 @@ function HomeContent() {
   const navLinks = [
     { name: 'Home', href: '/' },
     { name: 'Features', href: '/features' },
-    { name: 'About Us', href: '/about' },
+    // { name: 'About Us', href: '/about' },
     { name: 'Pricing', href: '/pricing' },
     { name: 'Contact', href: '/contact' },
   ];
@@ -677,14 +677,14 @@ function HomeContent() {
                 Company
               </h4>
               <ul className="space-y-2">
-                <li>
+                {/* <li>
                   <button
                     onClick={() => router.push('/about')}
                     className="text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
                   >
                     About Us
                   </button>
-                </li>
+                </li> */}
                 <li>
                   <button
                     onClick={() => router.push('/contact')}

--- a/components/home/marketing-footer.tsx
+++ b/components/home/marketing-footer.tsx
@@ -62,14 +62,14 @@ export function MarketingFooter() {
               Company
             </h4>
             <ul className="space-y-2">
-              <li>
+              {/* <li>
                 <Link
                   href="/about"
                   className="text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
                 >
                   About Us
                 </Link>
-              </li>
+              </li> */}
               <li>
                 <Link
                   href="/contact"

--- a/components/home/marketing-nav.tsx
+++ b/components/home/marketing-nav.tsx
@@ -17,7 +17,7 @@ export function MarketingNav({ currentPage }: MarketingNavProps) {
   const navLinks = [
     { name: 'Home', href: '/' },
     { name: 'Features', href: '/features' },
-    { name: 'About Us', href: '/about' },
+    // { name: 'About Us', href: '/about' },
     { name: 'Pricing', href: '/pricing' },
     { name: 'Contact', href: '/contact' },
   ];


### PR DESCRIPTION
## Description  
This pull request merges fixes from the `[quick-fix]` branch to address **navigation visibility** and **contact information accuracy**. The changes are focused on temporarily disabling the About Us entry points and ensuring all contact details reflect the correct domain and local context.

## Changes Made  

### Navigation & Footer Fixes
- Commented out **About Us** link in the main navigation.
- Commented out **About Us** link in the footer and related sections.
- Prevents users from navigating to the About page while content/flow decisions are finalized.

### Contact Information Updates
- Updated contact details to reflect **local information and correct time zone**.

## Testing  
- Verified navigation menu renders correctly without the About Us link.
- Confirmed footer layout remains intact after link removal.
- Checked all updated contact details render correctly across pages.
- Smoke-tested navigation and footer across desktop and mobile views.

## Impact  
- Prevents premature access to the About page from navigation and footer.
- Improves **brand consistency** by standardizing email domains.
- Ensures users see **accurate and locally relevant contact information**.
- Low-risk change suitable for immediate deployment.

## Related Issues  
- No directly linked issues.

## Checklist  
- [x] Navigation and footer tested  
- [x] Contact information verified  
- [x] No breaking changes introduced  
- [ ] Documentation updated (if applicable)  
- [x] Ready for merge  
