### PR TITLE
fix: remove custom cookie name override to prevent NextAuth v5 BFF token mismatch

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -79,19 +79,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
   session: { strategy: 'jwt' },
 
-  // Production cookie configuration for nginx reverse proxy
   useSecureCookies: process.env.NEXTAUTH_URL?.startsWith('https://'),
-  cookies: {
-    sessionToken: {
-      name: `${process.env.NODE_ENV === 'production' ? '__Secure-' : ''}next-auth.session-token`,
-      options: {
-        httpOnly: true,
-        sameSite: 'lax',
-        path: '/',
-        secure: process.env.NEXTAUTH_URL?.startsWith('https://'),
-      },
-    },
-  },
 
   providers: [
     KeycloakProvider({

--- a/lib/auth/get-session-tokens.ts
+++ b/lib/auth/get-session-tokens.ts
@@ -32,6 +32,7 @@ export async function getSessionTokens() {
       },
     } as { headers: { cookie: string } },
     secret: process.env.NEXTAUTH_SECRET,
+    secureCookie: process.env.NEXTAUTH_URL?.startsWith('https://'),
   });
 
   if (!token) {


### PR DESCRIPTION
## Problem

All authenticated API calls to the Spring Boot backend were returning **401 Unauthorized**
despite a successful Keycloak login. Users could reach the dashboard (the middleware
`auth()` call worked) but every request proxied through the BFF returned 401.

### Root cause

The app configured a custom session cookie name (`next-auth.session-token`, the v4
default) in `auth.ts`:

```ts
cookies: {
  sessionToken: {
    name: `...next-auth.session-token`,
  },
},
```

NextAuth v5 changed the default cookie name to `authjs.session-token`. The BFF proxy
reads the session via `getToken()` from `next-auth/jwt`, which, without an explicit
`cookieName`, fell back to looking for the **v5 default** — `authjs.session-token` —
and found nothing.

`getToken()` returned `null` → no `Authorization: Bearer` header was forwarded to
the backend → Spring Boot rejected every request with 401.

This went unnoticed because the two session-reading paths diverged silently:

| Path | Mechanism | Cookie name used |
|---|---|---|
| Middleware (`proxy.ts`) | `auth()` — NextAuth internal | Knows configured name ✓ |
| BFF route handler | `getToken()` — external call | Defaulted to v5 name ✗ |

There was also a secondary issue: in NextAuth v5, session tokens are JWE-encrypted.
The decryption key is derived via HKDF using the cookie name as the salt. A mismatched
`cookieName` means a mismatched salt → decryption fails even if the cookie is found.

## Solution

Remove the custom `cookies` override entirely. NextAuth v5's defaults (`authjs.session-token`,
`httpOnly`, `sameSite: lax`, `path: /`, `secure` driven by `useSecureCookies`) are
identical to what the override was explicitly setting. The override was redundant and
only created a divergence between how NextAuth wrote the cookie and how `getToken()`
read it.

In `getSessionTokens()`, pass `secureCookie` so `getToken()` derives the correct cookie
name and salt using the same `defaultCookies()` logic that NextAuth uses internally —
staying in sync automatically across future NextAuth updates.

```ts
// Before — hardcoded name, breaks on any NextAuth cookie rename
const cookieName = `...next-auth.session-token`;
await getToken({ ..., cookieName, salt: cookieName });

// After — delegates to NextAuth's own defaultCookies() logic
await getToken({ ..., secureCookie: process.env.NEXTAUTH_URL?.startsWith('https://') });
```

## Other changes in this PR

- **Credentials provider**: Hardcoded dev credentials (`admin@echno.com` / `$7zqY*u68`)
  replaced with `DEV_MOCK_EMAIL` / `DEV_MOCK_PASSWORD` env vars. The provider now fails
  closed (returns `null`) if the vars are unset rather than falling back to a hardcoded
  default. Credentials are no longer committed to the repo.

- **Profile fetch timeout**: Added `AbortController` with a configurable timeout
  (`TOKEN_REFRESH.USER_PROFILE_FETCH_TIMEOUT_MS`) to the user profile fetch inside the
  Keycloak JWT callback. A slow backend can no longer stall the login flow.

- **`getSessionTokens()` refactor**: Removed the redundant `auth()` call that was being
  made before `getToken()`. The function now reads directly from the encrypted JWT
  cookie, which is the correct BFF pattern — `auth()` runs the `jwt()` callback
  (refresh, revocation), `getToken()` reads the raw cookie for token forwarding.

- **`accessToken` removed from client session**: `session.accessToken` was being
  returned to the browser via `/api/auth/session`. Tokens must never be exposed to
  client JS in a BFF model; they are only needed server-side and are read from the
  encrypted JWT cookie by `getSessionTokens()`.

## Migration note

Removing the cookie name override changes the active cookie name from
`next-auth.session-token` to `authjs.session-token`. Existing browser sessions will be
invalidated and users will need to sign in once after this is deployed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified authentication session cookie configuration by reducing custom overrides and leveraging NextAuth's framework defaults. This improves code consistency and maintainability while preserving security by automatically adapting cookie protection settings based on whether the application is deployed in an HTTP or HTTPS environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tornotron/echno-web/pull/127)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->