### PR TITLE
feat(nav): migrate third-party module to route helpers (Phase 7)

### DIFF
--- a/app/users/dashboard/third-party/labour/[id]/edit/page.tsx
+++ b/app/users/dashboard/third-party/labour/[id]/edit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { routes } from '@/nav';
 import { Button } from '@/components/shadcn/button';
 import {
   Card,
@@ -71,7 +72,7 @@ export default function LabourFormPage() {
     toast.success(
       isEdit ? 'Labour updated successfully' : 'Labour created successfully'
     );
-    router.push('/dashboard/third-party/labour');
+    router.push(routes.thirdParty.labour.href);
   };
 
   const handleChange = (field: string, value: string) => {
@@ -390,7 +391,7 @@ export default function LabourFormPage() {
                 type="button"
                 variant="outline"
                 className="w-full"
-                onClick={() => router.push('/dashboard/third-party/labour')}
+                onClick={() => router.push(routes.thirdParty.labour.href)}
               >
                 Cancel
               </Button>

--- a/app/users/dashboard/third-party/labour/[id]/page.tsx
+++ b/app/users/dashboard/third-party/labour/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
 } from 'lucide-react';
 import { format } from 'date-fns';
 import Link from 'next/link';
+import { routes } from '@/nav';
 import { mockLabour, getLabourById } from '@/components/shared/mock-data';
 
 const typeLabels: Record<string, string> = {
@@ -76,9 +77,7 @@ export default function LabourDetailPage({ params }: PageProps) {
         </div>
         <div className="flex items-center space-x-2">
           <Button variant="outline" size="sm" asChild>
-            <Link
-              href={`/users/dashboard/third-party/labour/${labour.id}/edit`}
-            >
+            <Link href={routes.thirdParty.labour.detail(labour.id).edit}>
               <Edit className="mr-2 h-4 w-4" />
               Edit
             </Link>

--- a/app/users/dashboard/third-party/labour/new/page.tsx
+++ b/app/users/dashboard/third-party/labour/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { routes } from '@/nav';
 import { Button } from '@/components/shadcn/button';
 import {
   Card,
@@ -66,7 +67,7 @@ export default function NewLabourPage() {
 
     // Simulate API call
     toast.success('Labour created successfully');
-    router.push('/dashboard/third-party/labour');
+    router.push(routes.thirdParty.labour.href);
   };
 
   const handleChange = (field: string, value: string) => {
@@ -78,7 +79,7 @@ export default function NewLabourPage() {
       {/* Header */}
       <div className="flex items-center space-x-4">
         <Button variant="outline" size="icon" asChild>
-          <Link href="/users/dashboard/third-party/labour">
+          <Link href={routes.thirdParty.labour.href}>
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>
@@ -469,7 +470,7 @@ export default function NewLabourPage() {
                 type="button"
                 variant="outline"
                 className="w-full"
-                onClick={() => router.push('/dashboard/third-party/labour')}
+                onClick={() => router.push(routes.thirdParty.labour.href)}
               >
                 Cancel
               </Button>

--- a/app/users/dashboard/third-party/labour/page.tsx
+++ b/app/users/dashboard/third-party/labour/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Pagination, SearchAndFilter, PageHeader } from '@/components/common';
 import { Button } from '@/components/shadcn/button';
 import {
@@ -38,6 +39,7 @@ import {
 } from 'lucide-react';
 
 import Link from 'next/link';
+import { routes } from '@/nav';
 import { mockLabour } from '@/components/shared/mock-data';
 import { PhoneDisplay } from '@/components/shadcn/phone-input';
 
@@ -70,6 +72,7 @@ const skillLevelLabels = {
 };
 
 export default function LabourPage() {
+  const router = useRouter();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [typeFilter, setTypeFilter] = useState<string>('all');
@@ -165,7 +168,7 @@ export default function LabourPage() {
               Export
             </Button>
             <Button size="sm" asChild>
-              <Link href="/users/dashboard/third-party/labour/new">
+              <Link href={routes.thirdParty.labour.new}>
                 <Plus className="mr-2 h-4 w-4" />
                 Add Labour
               </Link>
@@ -360,7 +363,7 @@ export default function LabourPage() {
               key={labour.id}
               className="cursor-pointer"
               onClick={() =>
-                (globalThis.location.href = `/dashboard/third-party/labour/${labour.id}`)
+                router.push(routes.thirdParty.labour.detail(labour.id).href)
               }
             >
               <CardContent className="p-4">
@@ -460,7 +463,9 @@ export default function LabourPage() {
                     key={labour.id}
                     className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900"
                     onClick={() =>
-                      (globalThis.location.href = `/dashboard/third-party/labour/${labour.id}`)
+                      router.push(
+                        routes.thirdParty.labour.detail(labour.id).href
+                      )
                     }
                   >
                     <TableCell onClick={(e) => e.stopPropagation()}>

--- a/app/users/dashboard/third-party/sub-contracts/[id]/edit/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/[id]/edit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { routes } from '@/nav';
 import { Button } from '@/components/shadcn/button';
 import {
   Card,
@@ -189,15 +190,15 @@ export default function SubContractEditPage() {
           ? 'Sub-contract updated successfully'
           : 'Sub-contract created successfully'
       );
-      router.push('/dashboard/third-party/sub-contracts');
+      router.push(routes.thirdParty.subContracts.href);
     }, 500);
   };
 
   const handleCancel = () => {
     router.push(
       isEditMode
-        ? `/dashboard/third-party/sub-contracts/${params.id}`
-        : '/dashboard/third-party/sub-contracts'
+        ? routes.thirdParty.subContracts.detail(params.id as string).href
+        : routes.thirdParty.subContracts.href
     );
   };
 

--- a/app/users/dashboard/third-party/sub-contracts/[id]/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/[id]/page.tsx
@@ -30,6 +30,7 @@ import {
 } from 'lucide-react';
 import { format } from 'date-fns';
 import Link from 'next/link';
+import { routes } from '@/nav';
 
 // Mock data - replace with actual API call
 const mockSubContract = {
@@ -165,7 +166,7 @@ export default function SubContractDetailPage({ params }: PageProps) {
         <div className="flex items-center space-x-2">
           <Button variant="outline" size="sm" asChild>
             <Link
-              href={`/users/dashboard/third-party/sub-contracts/${subContract.id}/edit`}
+              href={routes.thirdParty.subContracts.detail(subContract.id).edit}
             >
               <Edit className="mr-2 h-4 w-4" />
               Edit

--- a/app/users/dashboard/third-party/sub-contracts/new/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { routes } from '@/nav';
 import { Button } from '@/components/shadcn/button';
 import {
   Card,
@@ -126,12 +127,12 @@ export default function SubContractNewPage() {
     // Simulate API call
     setTimeout(() => {
       toast.success('Sub-contract created successfully');
-      router.push('/dashboard/third-party/sub-contracts');
+      router.push(routes.thirdParty.subContracts.href);
     }, 500);
   };
 
   const handleCancel = () => {
-    router.push('/dashboard/third-party/sub-contracts');
+    router.push(routes.thirdParty.subContracts.href);
   };
 
   return (

--- a/app/users/dashboard/third-party/sub-contracts/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Pagination, SearchAndFilter, PageHeader } from '@/components/common';
 import { Button } from '@/components/shadcn/button';
 import { Checkbox } from '@/components/shadcn/checkbox';
@@ -40,6 +41,7 @@ import {
 } from 'lucide-react';
 import { format, differenceInDays } from 'date-fns';
 import Link from 'next/link';
+import { routes } from '@/nav';
 import { mockSubContracts } from '@/components/shared/mock-data';
 
 const typeLabels = {
@@ -90,6 +92,7 @@ const getProgressColor = (percentage: number) => {
 };
 
 export default function SubContractsPage() {
+  const router = useRouter();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [typeFilter, setTypeFilter] = useState<string>('all');
@@ -179,7 +182,7 @@ export default function SubContractsPage() {
               Export
             </Button>
             <Button size="sm" asChild>
-              <Link href="/users/dashboard/third-party/sub-contracts/new">
+              <Link href={routes.thirdParty.subContracts.new}>
                 <Plus className="mr-2 h-4 w-4" />
                 New Contract
               </Link>
@@ -377,7 +380,9 @@ export default function SubContractsPage() {
               key={contract.id}
               className="cursor-pointer"
               onClick={() =>
-                (globalThis.location.href = `/dashboard/third-party/sub-contracts/${contract.id}`)
+                router.push(
+                  routes.thirdParty.subContracts.detail(contract.id).href
+                )
               }
             >
               <CardContent className="p-4">
@@ -479,7 +484,10 @@ export default function SubContractsPage() {
                       key={contract.id}
                       className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900"
                       onClick={() =>
-                        (globalThis.location.href = `/dashboard/third-party/sub-contracts/${contract.id}`)
+                        router.push(
+                          routes.thirdParty.subContracts.detail(contract.id)
+                            .href
+                        )
                       }
                     >
                       <TableCell onClick={(e) => e.stopPropagation()}>

--- a/app/users/dashboard/third-party/vendors/[id]/page.tsx
+++ b/app/users/dashboard/third-party/vendors/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { use } from 'react';
 import { useRouter } from 'next/navigation';
+import { routes } from '@/nav';
 import Link from 'next/link';
 import { Button } from '@/components/shadcn/button';
 import { Badge } from '@/components/shadcn/badge';
@@ -50,9 +51,7 @@ export default function VendorDetailPage({ params }: PageProps) {
         <p className="text-zinc-500">
           &quot;{id}&quot; is not a valid vendor identifier.
         </p>
-        <Button
-          onClick={() => router.push('/users/dashboard/third-party/vendors')}
-        >
+        <Button onClick={() => router.push(routes.thirdParty.vendors.href)}>
           Back to Vendors
         </Button>
       </div>
@@ -77,9 +76,7 @@ export default function VendorDetailPage({ params }: PageProps) {
             ? error.message
             : `Vendor #${id} could not be found.`}
         </p>
-        <Button
-          onClick={() => router.push('/users/dashboard/third-party/vendors')}
-        >
+        <Button onClick={() => router.push(routes.thirdParty.vendors.href)}>
           Back to Vendors
         </Button>
       </div>
@@ -103,9 +100,7 @@ export default function VendorDetailPage({ params }: PageProps) {
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <Button variant="outline" size="sm" asChild>
-            <Link
-              href={`/users/dashboard/third-party/vendors/${vendor.id}/edit`}
-            >
+            <Link href={routes.thirdParty.vendors.detail(vendor.id).edit}>
               <Edit className="mr-2 h-4 w-4" /> Edit
             </Link>
           </Button>

--- a/app/users/dashboard/third-party/vendors/new/page.tsx
+++ b/app/users/dashboard/third-party/vendors/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { routes } from '@/nav';
 import { Button } from '@/components/shadcn/button';
 import {
   Card,
@@ -63,7 +64,7 @@ export default function VendorNewPage() {
     createVendor(form, {
       onSuccess: () => {
         toast.success('Vendor created successfully.');
-        router.push('/users/dashboard/third-party/vendors');
+        router.push(routes.thirdParty.vendors.href);
       },
       onError: (err) =>
         toast.error(
@@ -254,7 +255,7 @@ export default function VendorNewPage() {
           <Button
             type="button"
             variant="outline"
-            onClick={() => router.push('/users/dashboard/third-party/vendors')}
+            onClick={() => router.push(routes.thirdParty.vendors.href)}
           >
             <X className="mr-2 h-4 w-4" /> Cancel
           </Button>

--- a/app/users/dashboard/third-party/vendors/page.tsx
+++ b/app/users/dashboard/third-party/vendors/page.tsx
@@ -26,6 +26,7 @@ import {
   Search,
 } from 'lucide-react';
 import Link from 'next/link';
+import { routes } from '@/nav';
 import { useVendorsPaginated } from '@/hooks/vendors';
 import {
   VendorStatus,
@@ -105,7 +106,7 @@ export default function VendorsPage() {
           </p>
         </div>
         <Button size="sm" asChild>
-          <Link href="/users/dashboard/third-party/vendors/new">
+          <Link href={routes.thirdParty.vendors.new}>
             <Plus className="mr-2 h-4 w-4" />
             Add Vendor
           </Link>

--- a/features/vendor/components/vendor-editor.tsx
+++ b/features/vendor/components/vendor-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { routes } from '@/nav';
 import { Button } from '@/components/shadcn/button';
 import {
   Card,
@@ -70,7 +71,7 @@ export function VendorEditor({ vendor, vendorId }: VendorEditorProps) {
       {
         onSuccess: () => {
           toast.success('Vendor updated successfully.');
-          router.push(`/users/dashboard/third-party/vendors/${vendorId}`);
+          router.push(routes.thirdParty.vendors.detail(vendorId).href);
         },
         onError: (err) =>
           toast.error(
@@ -263,7 +264,7 @@ export function VendorEditor({ vendor, vendorId }: VendorEditorProps) {
             type="button"
             variant="outline"
             onClick={() =>
-              router.push(`/users/dashboard/third-party/vendors/${vendorId}`)
+              router.push(routes.thirdParty.vendors.detail(vendorId).href)
             }
           >
             <X className="mr-2 h-4 w-4" /> Cancel

--- a/features/vendor/components/vendor-table.tsx
+++ b/features/vendor/components/vendor-table.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { routes } from '@/nav';
 import { Pagination } from '@/components/common';
 import { Badge } from '@/components/shadcn/badge';
 import { Button } from '@/components/shadcn/button';
@@ -106,9 +107,7 @@ export function VendorTable({
                 key={vendor.id}
                 className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900"
                 onClick={() =>
-                  router.push(
-                    `/users/dashboard/third-party/vendors/${vendor.id}`
-                  )
+                  router.push(routes.thirdParty.vendors.detail(vendor.id).href)
                 }
               >
                 <TableCell>


### PR DESCRIPTION
## Description

This PR continues the migration from hardcoded URI strings to the centralized `routes.*` helper system, focusing on the Third Party module. It covers all submodules managing external entities, including Vendors, Labour, and Sub-contracts, ensuring all listing, detail, and edit navigation is type-safe.

## Changes Made

- **Third Party Module Migration**:
    - **Vendors**: Migrated listing, new, and detail pages to `routes.thirdParty.vendors`. Updated `vendor-table` and `vendor-editor` components.
    - **Labour**: Migrated listing, new, detail, and edit pages to `routes.thirdParty.labour`.
    - **Sub-contracts**: Migrated listing, new, detail, and edit pages to `routes.thirdParty.subContracts`.
- **Naming Conventions**:
    - Correctly applied camelCase keys for the `thirdParty` route helper as defined in the navigation config (e.g., `routes.thirdParty.subContracts` instead of hyphenated strings).

## Testing

- **Manual Verification**: 
    - Verified all third-party submodule listings and detail page navigation.
    - Tested navigation from listing tables to detail and edit views.
- **Grep Audit**: Confirmed that no hardcoded `/users/dashboard/third-party` strings remain in the migrated files.

## Impact

- **Type Safety**: Ensures all third-party navigation uses the generated route helpers.
- **Consistency**: Aligns the third-party module with the project-wide navigation standards.
- **Maintainability**: Simplifies future route changes for external entity management.

## Related Issues

- Continuation of the route helper migration (Phase 7 of 10).

## Checklist

- [x] Code has been reviewed by at least one team member.
- [x] Documentation has been updated.
- [x] Changes follow the established coding standards and best practices.
- [ ] Tests have been written and/or existing tests have been updated (if applicable).
- [x] Relevant issues have been addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation throughout the third-party management section (vendors, labour, and sub-contracts) to use centralized route definitions instead of hardcoded paths.
  * Replaced `globalThis.location.href` with Next.js `useRouter().push()` for client-side navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tornotron/echno-web/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->