### PR TITLE
refactor(third-party): standardizing UI/UX patterns (Phases 1-2)

### DIFF
--- a/app/users/dashboard/third-party/labour/[id]/edit/page.tsx
+++ b/app/users/dashboard/third-party/labour/[id]/edit/page.tsx
@@ -23,6 +23,7 @@ import {
   SelectValue,
 } from '@/components/shadcn/select';
 import { Save, HardHat } from 'lucide-react';
+import { PageHeader } from '@/components/common';
 import { toast } from '@/lib/styles/toast-styles';
 import { getLabourById } from '@/components/shared/mock-data';
 import {
@@ -106,17 +107,12 @@ export default function LabourFormPage() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Header */}
-      <div className="flex items-center space-x-4">
-        <div>
-          <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            {isEdit ? 'Edit Labour' : 'Add New Labour'}
-          </h1>
-          <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-            {isEdit ? 'Update labour information' : 'Enter new labour details'}
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title={isEdit ? 'Edit Labour' : 'Add New Labour'}
+        description={
+          isEdit ? 'Update labour information' : 'Enter new labour details'
+        }
+      />
 
       <form onSubmit={handleSubmit}>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/app/users/dashboard/third-party/labour/[id]/edit/page.tsx
+++ b/app/users/dashboard/third-party/labour/[id]/edit/page.tsx
@@ -22,9 +22,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/shadcn/select';
-import { Save } from 'lucide-react';
+import { Save, HardHat } from 'lucide-react';
 import { toast } from '@/lib/styles/toast-styles';
 import { getLabourById } from '@/components/shared/mock-data';
+import {
+  Empty,
+  EmptyErrorMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
+import Link from 'next/link';
 import { format } from 'date-fns';
 
 export default function LabourFormPage() {
@@ -57,7 +65,24 @@ export default function LabourFormPage() {
     emergencyContactPhone: mockLabourData?.emergencyContactPhone || '',
   });
 
-  // No useEffect needed since we initialize state above
+  if (isEdit && !mockLabourData) {
+    return (
+      <Empty variant="default">
+        <EmptyErrorMedia>
+          <HardHat className="size-6" />
+        </EmptyErrorMedia>
+        <EmptyHeader>
+          <EmptyTitle>Labour record not found</EmptyTitle>
+          <EmptyDescription>
+            This record may have been deleted or does not exist.
+          </EmptyDescription>
+        </EmptyHeader>
+        <Button asChild>
+          <Link href={routes.thirdParty.labour.href}>Back to Labour</Link>
+        </Button>
+      </Empty>
+    );
+  }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/users/dashboard/third-party/labour/[id]/page.tsx
+++ b/app/users/dashboard/third-party/labour/[id]/page.tsx
@@ -24,7 +24,14 @@ import {
 import { format } from 'date-fns';
 import Link from 'next/link';
 import { routes } from '@/nav';
-import { mockLabour, getLabourById } from '@/components/shared/mock-data';
+import { getLabourById } from '@/components/shared/mock-data';
+import {
+  Empty,
+  EmptyErrorMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
 
 const typeLabels: Record<string, string> = {
   daily: 'Daily Wage',
@@ -61,7 +68,26 @@ interface PageProps {
 export default function LabourDetailPage({ params }: PageProps) {
   const { id } = params;
   const labourId = Number.parseInt(id);
-  const labour = getLabourById(labourId) || mockLabour[0];
+  const labour = getLabourById(labourId);
+
+  if (!labour) {
+    return (
+      <Empty variant="default">
+        <EmptyErrorMedia>
+          <HardHat className="size-6" />
+        </EmptyErrorMedia>
+        <EmptyHeader>
+          <EmptyTitle>Labour record not found</EmptyTitle>
+          <EmptyDescription>
+            This record may have been deleted or does not exist.
+          </EmptyDescription>
+        </EmptyHeader>
+        <Button asChild>
+          <Link href={routes.thirdParty.labour.href}>Back to Labour</Link>
+        </Button>
+      </Empty>
+    );
+  }
 
   return (
     <div className="space-y-4 sm:space-y-6">

--- a/app/users/dashboard/third-party/labour/[id]/page.tsx
+++ b/app/users/dashboard/third-party/labour/[id]/page.tsx
@@ -21,6 +21,7 @@ import {
   User,
   HardHat,
 } from 'lucide-react';
+import { PageHeader } from '@/components/common';
 import { format } from 'date-fns';
 import Link from 'next/link';
 import { routes } from '@/nav';
@@ -91,33 +92,28 @@ export default function LabourDetailPage({ params }: PageProps) {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Header */}
-      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-        <div>
-          <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            {labour.name}
-          </h1>
-          <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-            Labour ID: {labour.labourId}
-          </p>
-        </div>
-        <div className="flex items-center space-x-2">
-          <Button variant="outline" size="sm" asChild>
-            <Link href={routes.thirdParty.labour.detail(labour.id).edit}>
-              <Edit className="mr-2 h-4 w-4" />
-              Edit
-            </Link>
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-red-600 hover:text-red-700"
-          >
-            <Trash2 className="mr-2 h-4 w-4" />
-            Delete
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title={labour.name}
+        description={`Labour ID: ${labour.labourId}`}
+        actions={
+          <>
+            <Button variant="outline" size="sm" asChild>
+              <Link href={routes.thirdParty.labour.detail(labour.id).edit}>
+                <Edit className="mr-2 h-4 w-4" />
+                Edit
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-red-600 hover:text-red-700"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete
+            </Button>
+          </>
+        }
+      />
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         {/* Main Info */}

--- a/app/users/dashboard/third-party/labour/new/page.tsx
+++ b/app/users/dashboard/third-party/labour/new/page.tsx
@@ -22,8 +22,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/shadcn/select';
-import { ArrowLeft, Save } from 'lucide-react';
-import Link from 'next/link';
+import { Save } from 'lucide-react';
+import { PageHeader } from '@/components/common';
 import { toast } from '@/lib/styles/toast-styles';
 
 export default function NewLabourPage() {
@@ -76,22 +76,10 @@ export default function NewLabourPage() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Header */}
-      <div className="flex items-center space-x-4">
-        <Button variant="outline" size="icon" asChild>
-          <Link href={routes.thirdParty.labour.href}>
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-        </Button>
-        <div>
-          <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            Add New Labour
-          </h1>
-          <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-            Enter new labour details
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title="Add New Labour"
+        description="Enter new labour details"
+      />
 
       <form onSubmit={handleSubmit}>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/app/users/dashboard/third-party/labour/page.tsx
+++ b/app/users/dashboard/third-party/labour/page.tsx
@@ -42,6 +42,13 @@ import Link from 'next/link';
 import { routes } from '@/nav';
 import { mockLabour } from '@/components/shared/mock-data';
 import { PhoneDisplay } from '@/components/shadcn/phone-input';
+import {
+  Empty,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
 
 const typeLabels = {
   daily: 'Daily Wage',
@@ -352,11 +359,21 @@ export default function LabourPage() {
       {/* Mobile Card View */}
       <div className="space-y-3 md:grid md:grid-cols-2 md:gap-4 md:space-y-0 lg:hidden">
         {paginatedLabour.length === 0 ? (
-          <Card>
-            <CardContent className="py-8 text-center text-zinc-500">
-              No labour records found
-            </CardContent>
-          </Card>
+          <div className="py-4">
+            <Empty variant="default">
+              <EmptyMedia variant="icon">
+                <HardHat className="size-6" />
+              </EmptyMedia>
+              <EmptyHeader>
+                <EmptyTitle>No labour records found</EmptyTitle>
+                <EmptyDescription>
+                  {hasActiveFilters
+                    ? 'Try adjusting your search or filters.'
+                    : 'Add your first labour record to get started.'}
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          </div>
         ) : (
           paginatedLabour.map((labour) => (
             <Card
@@ -425,137 +442,149 @@ export default function LabourPage() {
       {/* Labour Table */}
       <Card className="hidden lg:block">
         <CardContent className="p-0">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-12">
-                  <Checkbox
-                    checked={isAllSelected}
-                    onCheckedChange={handleSelectAll}
-                    aria-label="Select all"
-                    className={
-                      isSomeSelected ? 'data-[state=checked]:bg-primary/50' : ''
-                    }
-                  />
-                </TableHead>
-                <TableHead>Name & Contact</TableHead>
-                <TableHead>Trade</TableHead>
-                <TableHead>Type</TableHead>
-                <TableHead>Rate</TableHead>
-                <TableHead>Project</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Outstanding</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {paginatedLabour.length === 0 ? (
-                <TableRow>
-                  <TableCell
-                    colSpan={8}
-                    className="py-8 text-center text-zinc-500"
-                  >
-                    No labour records found
-                  </TableCell>
-                </TableRow>
-              ) : (
-                paginatedLabour.map((labour) => (
-                  <TableRow
-                    key={labour.id}
-                    className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900"
-                    onClick={() =>
-                      router.push(
-                        routes.thirdParty.labour.detail(labour.id).href
-                      )
-                    }
-                  >
-                    <TableCell onClick={(e) => e.stopPropagation()}>
+          {paginatedLabour.length > 0 ? (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-12">
                       <Checkbox
-                        checked={selectedIds.includes(labour.id)}
-                        onCheckedChange={(checked) =>
-                          handleSelectOne(labour.id, checked as boolean)
+                        checked={isAllSelected}
+                        onCheckedChange={handleSelectAll}
+                        aria-label="Select all"
+                        className={
+                          isSomeSelected
+                            ? 'data-[state=checked]:bg-primary/50'
+                            : ''
                         }
-                        aria-label={`Select ${labour.name}`}
                       />
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center space-x-3">
-                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-orange-500 to-orange-600">
-                          <User className="h-5 w-5 text-white" />
+                    </TableHead>
+                    <TableHead>Name & Contact</TableHead>
+                    <TableHead>Trade</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Rate</TableHead>
+                    <TableHead>Project</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Outstanding</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {paginatedLabour.map((labour) => (
+                    <TableRow
+                      key={labour.id}
+                      className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900"
+                      onClick={() =>
+                        router.push(
+                          routes.thirdParty.labour.detail(labour.id).href
+                        )
+                      }
+                    >
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <Checkbox
+                          checked={selectedIds.includes(labour.id)}
+                          onCheckedChange={(checked) =>
+                            handleSelectOne(labour.id, checked as boolean)
+                          }
+                          aria-label={`Select ${labour.name}`}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center space-x-3">
+                          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-orange-500 to-orange-600">
+                            <User className="h-5 w-5 text-white" />
+                          </div>
+                          <div>
+                            <p className="font-medium text-zinc-900 dark:text-zinc-100">
+                              {labour.name}
+                            </p>
+                            <PhoneDisplay
+                              value={labour.phone}
+                              className="text-zinc-500 dark:text-zinc-500"
+                            />
+                          </div>
                         </div>
+                      </TableCell>
+                      <TableCell>
                         <div>
-                          <p className="font-medium text-zinc-900 dark:text-zinc-100">
-                            {labour.name}
-                          </p>
-                          <PhoneDisplay
-                            value={labour.phone}
-                            className="text-zinc-500 dark:text-zinc-500"
-                          />
+                          <div>{labour.trade}</div>
+                          <div className="text-xs text-zinc-500">
+                            {
+                              skillLevelLabels[
+                                labour.skillLevel as keyof typeof skillLevelLabels
+                              ]
+                            }
+                          </div>
                         </div>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <div>
-                        <div>{labour.trade}</div>
-                        <div className="text-xs text-zinc-500">
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline">
+                          {typeLabels[labour.type as keyof typeof typeLabels]}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        {labour.dailyRate && `₹${labour.dailyRate}/day`}
+                        {labour.monthlyRate &&
+                          `₹${labour.monthlyRate.toLocaleString()}/mo`}
+                      </TableCell>
+                      <TableCell>
+                        <div className="text-sm">{labour.currentProject}</div>
+                        {labour.contractorName && (
+                          <div className="text-xs text-zinc-500">
+                            {labour.contractorName}
+                          </div>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          className={`bg-${statusColors[labour.status as keyof typeof statusColors]}-100 text-${statusColors[labour.status as keyof typeof statusColors]}-700 dark:bg-${statusColors[labour.status as keyof typeof statusColors]}-900 dark:text-${statusColors[labour.status as keyof typeof statusColors]}-300`}
+                        >
                           {
-                            skillLevelLabels[
-                              labour.skillLevel as keyof typeof skillLevelLabels
+                            statusLabels[
+                              labour.status as keyof typeof statusLabels
                             ]
                           }
-                        </div>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant="outline">
-                        {typeLabels[labour.type as keyof typeof typeLabels]}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      {labour.dailyRate && `₹${labour.dailyRate}/day`}
-                      {labour.monthlyRate &&
-                        `₹${labour.monthlyRate.toLocaleString()}/mo`}
-                    </TableCell>
-                    <TableCell>
-                      <div className="text-sm">{labour.currentProject}</div>
-                      {labour.contractorName && (
-                        <div className="text-xs text-zinc-500">
-                          {labour.contractorName}
-                        </div>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <Badge
-                        className={`bg-${statusColors[labour.status as keyof typeof statusColors]}-100 text-${statusColors[labour.status as keyof typeof statusColors]}-700 dark:bg-${statusColors[labour.status as keyof typeof statusColors]}-900 dark:text-${statusColors[labour.status as keyof typeof statusColors]}-300`}
-                      >
-                        {
-                          statusLabels[
-                            labour.status as keyof typeof statusLabels
-                          ]
-                        }
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      {labour.totalDue && labour.totalDue > 0 ? (
-                        <span className="font-semibold text-orange-600 dark:text-orange-400">
-                          ₹{labour.totalDue.toLocaleString()}
-                        </span>
-                      ) : (
-                        <span className="text-zinc-500">-</span>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-
-          {/* Pagination Controls */}
-          {filteredLabour.length > 0 && (
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={setCurrentPage}
-            />
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        {labour.totalDue && labour.totalDue > 0 ? (
+                          <span className="font-semibold text-orange-600 dark:text-orange-400">
+                            ₹{labour.totalDue.toLocaleString()}
+                          </span>
+                        ) : (
+                          <span className="text-zinc-500">-</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={setCurrentPage}
+              />
+            </>
+          ) : (
+            <div className="py-12">
+              <Empty variant="default">
+                <EmptyMedia variant="icon">
+                  <HardHat className="size-6" />
+                </EmptyMedia>
+                <EmptyHeader>
+                  <EmptyTitle>No labour records found</EmptyTitle>
+                  <EmptyDescription>
+                    {hasActiveFilters
+                      ? 'Try adjusting your search or filters.'
+                      : 'Add your first labour record to get started.'}
+                  </EmptyDescription>
+                </EmptyHeader>
+                {!hasActiveFilters && (
+                  <Button asChild>
+                    <Link href={routes.thirdParty.labour.new}>Add Labour</Link>
+                  </Button>
+                )}
+              </Empty>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/app/users/dashboard/third-party/sub-contracts/[id]/edit/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/[id]/edit/page.tsx
@@ -32,6 +32,14 @@ import {
   Trash2,
   TrendingUp,
 } from 'lucide-react';
+import Link from 'next/link';
+import {
+  Empty,
+  EmptyErrorMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
 
 // Mock data
 const mockSubContract = {
@@ -98,38 +106,60 @@ export default function SubContractEditPage() {
   const params = useParams();
   const router = useRouter();
   const isEditMode = params.id !== 'new';
+  const subContractData = isEditMode
+    ? (mockSubContract as typeof mockSubContract | null)
+    : null;
 
   const [formData, setFormData] = useState(
-    isEditMode
-      ? mockSubContract
-      : {
-          contractId: '',
-          contractorName: '',
-          contactPerson: '',
-          phone: '',
-          email: '',
-          address: '',
-          workType: 'construction',
-          status: 'active',
-          contractStatus: 'draft',
-          scope: '',
-          contractValue: 0,
-          paidAmount: 0,
-          pendingAmount: 0,
-          startDate: new Date().toISOString().split('T')[0],
-          endDate: '',
-          completionPercentage: 0,
-          gstNumber: '',
-          panNumber: '',
-          bankAccount: '',
-          bankName: '',
-          ifscCode: '',
-          contractDate: new Date().toISOString().split('T')[0],
-          paymentTerms: 'milestone',
-          milestones: [] as Milestone[],
-          notes: '',
-        }
+    subContractData ?? {
+      contractId: '',
+      contractorName: '',
+      contactPerson: '',
+      phone: '',
+      email: '',
+      address: '',
+      workType: 'construction',
+      status: 'active',
+      contractStatus: 'draft',
+      scope: '',
+      contractValue: 0,
+      paidAmount: 0,
+      pendingAmount: 0,
+      startDate: new Date().toISOString().split('T')[0],
+      endDate: '',
+      completionPercentage: 0,
+      gstNumber: '',
+      panNumber: '',
+      bankAccount: '',
+      bankName: '',
+      ifscCode: '',
+      contractDate: new Date().toISOString().split('T')[0],
+      paymentTerms: 'milestone',
+      milestones: [] as Milestone[],
+      notes: '',
+    }
   );
+
+  if (isEditMode && !subContractData) {
+    return (
+      <Empty variant="default">
+        <EmptyErrorMedia>
+          <FileText className="size-6" />
+        </EmptyErrorMedia>
+        <EmptyHeader>
+          <EmptyTitle>Sub-contract not found</EmptyTitle>
+          <EmptyDescription>
+            This record may have been deleted or does not exist.
+          </EmptyDescription>
+        </EmptyHeader>
+        <Button asChild>
+          <Link href={routes.thirdParty.subContracts.href}>
+            Back to Sub-Contracts
+          </Link>
+        </Button>
+      </Empty>
+    );
+  }
 
   const handleInputChange = (field: string, value: string | number) => {
     setFormData((prev) => {

--- a/app/users/dashboard/third-party/sub-contracts/[id]/edit/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/[id]/edit/page.tsx
@@ -32,6 +32,7 @@ import {
   Trash2,
   TrendingUp,
 } from 'lucide-react';
+import { PageHeader } from '@/components/common';
 import Link from 'next/link';
 import {
   Empty,
@@ -234,19 +235,14 @@ export default function SubContractEditPage() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Header */}
-      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-        <div>
-          <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            {isEditMode ? 'Edit Sub-Contract' : 'Add New Sub-Contract'}
-          </h1>
-          <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-            {isEditMode
-              ? `Update sub-contract information for ${formData.contractorName}`
-              : 'Fill in the details to add a new sub-contract'}
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title={isEditMode ? 'Edit Sub-Contract' : 'Add New Sub-Contract'}
+        description={
+          isEditMode
+            ? `Update sub-contract information for ${formData.contractorName}`
+            : 'Fill in the details to add a new sub-contract'
+        }
+      />
 
       <form onSubmit={handleSubmit}>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/app/users/dashboard/third-party/sub-contracts/[id]/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
   Clock,
   LucideIcon,
 } from 'lucide-react';
+import { PageHeader } from '@/components/common';
 import { format } from 'date-fns';
 import Link from 'next/link';
 import { routes } from '@/nav';
@@ -178,35 +179,32 @@ export default function SubContractDetailPage({ params }: PageProps) {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Header */}
-      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-        <div>
-          <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            {subContract.contractorName}
-          </h1>
-          <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-            Contract ID: {subContract.contractId}
-          </p>
-        </div>
-        <div className="flex items-center space-x-2">
-          <Button variant="outline" size="sm" asChild>
-            <Link
-              href={routes.thirdParty.subContracts.detail(subContract.id).edit}
+      <PageHeader
+        title={subContract.contractorName}
+        description={`Contract ID: ${subContract.contractId}`}
+        actions={
+          <>
+            <Button variant="outline" size="sm" asChild>
+              <Link
+                href={
+                  routes.thirdParty.subContracts.detail(subContract.id).edit
+                }
+              >
+                <Edit className="mr-2 h-4 w-4" />
+                Edit
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-red-600 hover:text-red-700"
             >
-              <Edit className="mr-2 h-4 w-4" />
-              Edit
-            </Link>
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-red-600 hover:text-red-700"
-          >
-            <Trash2 className="mr-2 h-4 w-4" />
-            Delete
-          </Button>
-        </div>
-      </div>
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete
+            </Button>
+          </>
+        }
+      />
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         {/* Main Info */}

--- a/app/users/dashboard/third-party/sub-contracts/[id]/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/[id]/page.tsx
@@ -31,6 +31,13 @@ import {
 import { format } from 'date-fns';
 import Link from 'next/link';
 import { routes } from '@/nav';
+import {
+  Empty,
+  EmptyErrorMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
 
 // Mock data - replace with actual API call
 const mockSubContract = {
@@ -146,10 +153,28 @@ interface PageProps {
 
 export default function SubContractDetailPage({ params }: PageProps) {
   use(params);
-  // The router import was unused and has been removed.
-  // The useState for subContract was unused and has been removed.
-  // Assuming `subContract` should directly use `mockSubContract` for now.
   const subContract = mockSubContract;
+
+  if (!subContract) {
+    return (
+      <Empty variant="default">
+        <EmptyErrorMedia>
+          <FileText className="size-6" />
+        </EmptyErrorMedia>
+        <EmptyHeader>
+          <EmptyTitle>Sub-contract not found</EmptyTitle>
+          <EmptyDescription>
+            This record may have been deleted or does not exist.
+          </EmptyDescription>
+        </EmptyHeader>
+        <Button asChild>
+          <Link href={routes.thirdParty.subContracts.href}>
+            Back to Sub-Contracts
+          </Link>
+        </Button>
+      </Empty>
+    );
+  }
 
   return (
     <div className="space-y-4 sm:space-y-6">

--- a/app/users/dashboard/third-party/sub-contracts/new/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/new/page.tsx
@@ -32,6 +32,7 @@ import {
   Trash2,
   TrendingUp,
 } from 'lucide-react';
+import { PageHeader } from '@/components/common';
 
 interface Milestone {
   name: string;
@@ -137,17 +138,10 @@ export default function SubContractNewPage() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Header */}
-      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-        <div>
-          <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            Add New Sub-Contract
-          </h1>
-          <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-            Fill in the details to add a new sub-contract
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        title="Add New Sub-Contract"
+        description="Fill in the details to add a new sub-contract"
+      />
 
       <form onSubmit={handleSubmit}>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/app/users/dashboard/third-party/sub-contracts/page.tsx
+++ b/app/users/dashboard/third-party/sub-contracts/page.tsx
@@ -43,6 +43,13 @@ import { format, differenceInDays } from 'date-fns';
 import Link from 'next/link';
 import { routes } from '@/nav';
 import { mockSubContracts } from '@/components/shared/mock-data';
+import {
+  Empty,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
 
 const typeLabels = {
   lumpsum: 'Lump Sum',
@@ -369,11 +376,21 @@ export default function SubContractsPage() {
       {/* Mobile Card View */}
       <div className="space-y-3 md:grid md:grid-cols-2 md:gap-4 md:space-y-0 lg:hidden">
         {paginatedContracts.length === 0 ? (
-          <Card>
-            <CardContent className="py-8 text-center text-zinc-500">
-              No contract records found
-            </CardContent>
-          </Card>
+          <div className="py-4">
+            <Empty variant="default">
+              <EmptyMedia variant="icon">
+                <FileText className="size-6" />
+              </EmptyMedia>
+              <EmptyHeader>
+                <EmptyTitle>No contracts found</EmptyTitle>
+                <EmptyDescription>
+                  {hasActiveFilters
+                    ? 'Try adjusting your search or filters.'
+                    : 'Add your first sub-contract to get started.'}
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          </div>
         ) : (
           paginatedContracts.map((contract) => (
             <Card
@@ -440,179 +457,194 @@ export default function SubContractsPage() {
       {/* Filters and Table */}
       <Card className="hidden lg:block">
         <CardContent className="p-0">
-          {/* Table */}
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-12">
-                  <Checkbox
-                    checked={isAllSelected}
-                    onCheckedChange={handleSelectAll}
-                    aria-label="Select all"
-                  />
-                </TableHead>
-                <TableHead>Contract Details</TableHead>
-                <TableHead>Contractor</TableHead>
-                <TableHead>Type</TableHead>
-                <TableHead>Progress</TableHead>
-                <TableHead>Value</TableHead>
-                <TableHead>Outstanding</TableHead>
-                <TableHead>Status</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {paginatedContracts.length === 0 ? (
-                <TableRow>
-                  <TableCell
-                    colSpan={8}
-                    className="py-8 text-center text-zinc-500"
-                  >
-                    No contract records found
-                  </TableCell>
-                </TableRow>
-              ) : (
-                paginatedContracts.map((contract) => {
-                  const daysRemaining = differenceInDays(
-                    contract.endDate,
-                    new Date()
-                  );
-                  const isNearDeadline =
-                    daysRemaining > 0 && daysRemaining <= 30;
+          {paginatedContracts.length > 0 ? (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-12">
+                      <Checkbox
+                        checked={isAllSelected}
+                        onCheckedChange={handleSelectAll}
+                        aria-label="Select all"
+                      />
+                    </TableHead>
+                    <TableHead>Contract Details</TableHead>
+                    <TableHead>Contractor</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Progress</TableHead>
+                    <TableHead>Value</TableHead>
+                    <TableHead>Outstanding</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {paginatedContracts.map((contract) => {
+                    const daysRemaining = differenceInDays(
+                      contract.endDate,
+                      new Date()
+                    );
+                    const isNearDeadline =
+                      daysRemaining > 0 && daysRemaining <= 30;
 
-                  return (
-                    <TableRow
-                      key={contract.id}
-                      className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900"
-                      onClick={() =>
-                        router.push(
-                          routes.thirdParty.subContracts.detail(contract.id)
-                            .href
-                        )
-                      }
-                    >
-                      <TableCell onClick={(e) => e.stopPropagation()}>
-                        <Checkbox
-                          checked={selectedIds.includes(contract.id)}
-                          onCheckedChange={(checked) =>
-                            handleSelectOne(contract.id, checked as boolean)
-                          }
-                          aria-label={`Select ${contract.contractId}`}
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <div>
-                          <div className="font-medium">
-                            {contract.contractName}
-                          </div>
-                          <div className="text-sm text-zinc-500">
-                            {contract.projectName}
-                          </div>
-                          <div className="mt-1 flex items-center space-x-1 text-xs text-zinc-400">
-                            <Clock className="h-3 w-3" />
-                            <span>
-                              {format(contract.endDate, 'MMM d, yyyy')}
-                            </span>
-                            {isNearDeadline && (
-                              <AlertCircle className="ml-1 h-3 w-3 text-orange-500" />
-                            )}
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center space-x-3">
-                          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-blue-500 to-blue-600">
-                            <User className="h-5 w-5 text-white" />
-                          </div>
+                    return (
+                      <TableRow
+                        key={contract.id}
+                        className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900"
+                        onClick={() =>
+                          router.push(
+                            routes.thirdParty.subContracts.detail(contract.id)
+                              .href
+                          )
+                        }
+                      >
+                        <TableCell onClick={(e) => e.stopPropagation()}>
+                          <Checkbox
+                            checked={selectedIds.includes(contract.id)}
+                            onCheckedChange={(checked) =>
+                              handleSelectOne(contract.id, checked as boolean)
+                            }
+                            aria-label={`Select ${contract.contractId}`}
+                          />
+                        </TableCell>
+                        <TableCell>
                           <div>
-                            <p className="font-medium text-zinc-900 dark:text-zinc-100">
-                              {contract.contractorName}
-                            </p>
-                            <p className="text-sm text-zinc-500 dark:text-zinc-500">
-                              {contract.contactPerson}
-                            </p>
+                            <div className="font-medium">
+                              {contract.contractName}
+                            </div>
+                            <div className="text-sm text-zinc-500">
+                              {contract.projectName}
+                            </div>
+                            <div className="mt-1 flex items-center space-x-1 text-xs text-zinc-400">
+                              <Clock className="h-3 w-3" />
+                              <span>
+                                {format(contract.endDate, 'MMM d, yyyy')}
+                              </span>
+                              {isNearDeadline && (
+                                <AlertCircle className="ml-1 h-3 w-3 text-orange-500" />
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline">
-                          {typeLabels[contract.type as keyof typeof typeLabels]}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className="w-full">
-                          <div className="mb-1 flex items-center justify-between">
-                            <span className="text-sm font-medium">
-                              {contract.completionPercentage}%
-                            </span>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center space-x-3">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-blue-500 to-blue-600">
+                              <User className="h-5 w-5 text-white" />
+                            </div>
+                            <div>
+                              <p className="font-medium text-zinc-900 dark:text-zinc-100">
+                                {contract.contractorName}
+                              </p>
+                              <p className="text-sm text-zinc-500 dark:text-zinc-500">
+                                {contract.contactPerson}
+                              </p>
+                            </div>
                           </div>
-                          <div className="h-2 w-full rounded-full bg-zinc-200 dark:bg-zinc-700">
-                            <div
-                              className={`h-2 rounded-full ${getProgressColor(contract.completionPercentage)}`}
-                              style={{
-                                width: `${contract.completionPercentage}%`,
-                              }}
-                            />
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="font-semibold text-blue-600 dark:text-blue-400">
-                          ₹{(contract.contractValue / 100_000).toFixed(1)}L
-                        </div>
-                        <div className="text-xs text-zinc-500">
-                          Paid: ₹{(contract.totalPaid / 100_000).toFixed(1)}L
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        {contract.totalDue > 0 ? (
-                          <span className="font-semibold text-orange-600 dark:text-orange-400">
-                            ₹{(contract.totalDue / 100_000).toFixed(1)}L
-                          </span>
-                        ) : (
-                          <span className="text-green-600 dark:text-green-400">
-                            Paid
-                          </span>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        <div className="space-y-1">
-                          <Badge
-                            className={`bg-${statusColors[contract.status as keyof typeof statusColors]}-100 text-${statusColors[contract.status as keyof typeof statusColors]}-700 dark:bg-${statusColors[contract.status as keyof typeof statusColors]}-900 dark:text-${statusColors[contract.status as keyof typeof statusColors]}-300`}
-                          >
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">
                             {
-                              statusLabels[
-                                contract.status as keyof typeof statusLabels
+                              typeLabels[
+                                contract.type as keyof typeof typeLabels
                               ]
                             }
                           </Badge>
-                          <div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="w-full">
+                            <div className="mb-1 flex items-center justify-between">
+                              <span className="text-sm font-medium">
+                                {contract.completionPercentage}%
+                              </span>
+                            </div>
+                            <div className="h-2 w-full rounded-full bg-zinc-200 dark:bg-zinc-700">
+                              <div
+                                className={`h-2 rounded-full ${getProgressColor(contract.completionPercentage)}`}
+                                style={{
+                                  width: `${contract.completionPercentage}%`,
+                                }}
+                              />
+                            </div>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="font-semibold text-blue-600 dark:text-blue-400">
+                            ₹{(contract.contractValue / 100_000).toFixed(1)}L
+                          </div>
+                          <div className="text-xs text-zinc-500">
+                            Paid: ₹{(contract.totalPaid / 100_000).toFixed(1)}L
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          {contract.totalDue > 0 ? (
+                            <span className="font-semibold text-orange-600 dark:text-orange-400">
+                              ₹{(contract.totalDue / 100_000).toFixed(1)}L
+                            </span>
+                          ) : (
+                            <span className="text-green-600 dark:text-green-400">
+                              Paid
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <div className="space-y-1">
                             <Badge
-                              variant="outline"
-                              className={`text-xs bg-${paymentStatusColors[contract.paymentStatus as keyof typeof paymentStatusColors]}-50 border-${paymentStatusColors[contract.paymentStatus as keyof typeof paymentStatusColors]}-200`}
+                              className={`bg-${statusColors[contract.status as keyof typeof statusColors]}-100 text-${statusColors[contract.status as keyof typeof statusColors]}-700 dark:bg-${statusColors[contract.status as keyof typeof statusColors]}-900 dark:text-${statusColors[contract.status as keyof typeof statusColors]}-300`}
                             >
                               {
-                                paymentStatusLabels[
-                                  contract.paymentStatus as keyof typeof paymentStatusLabels
+                                statusLabels[
+                                  contract.status as keyof typeof statusLabels
                                 ]
                               }
                             </Badge>
+                            <div>
+                              <Badge
+                                variant="outline"
+                                className={`text-xs bg-${paymentStatusColors[contract.paymentStatus as keyof typeof paymentStatusColors]}-50 border-${paymentStatusColors[contract.paymentStatus as keyof typeof paymentStatusColors]}-200`}
+                              >
+                                {
+                                  paymentStatusLabels[
+                                    contract.paymentStatus as keyof typeof paymentStatusLabels
+                                  ]
+                                }
+                              </Badge>
+                            </div>
                           </div>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
-              )}
-            </TableBody>
-          </Table>
-
-          {/* Pagination Controls */}
-          {filteredContracts.length > 0 && (
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={setCurrentPage}
-            />
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={setCurrentPage}
+              />
+            </>
+          ) : (
+            <div className="py-12">
+              <Empty variant="default">
+                <EmptyMedia variant="icon">
+                  <FileText className="size-6" />
+                </EmptyMedia>
+                <EmptyHeader>
+                  <EmptyTitle>No contracts found</EmptyTitle>
+                  <EmptyDescription>
+                    {hasActiveFilters
+                      ? 'Try adjusting your search or filters.'
+                      : 'Add your first sub-contract to get started.'}
+                  </EmptyDescription>
+                </EmptyHeader>
+                {!hasActiveFilters && (
+                  <Button asChild>
+                    <Link href={routes.thirdParty.subContracts.new}>
+                      New Contract
+                    </Link>
+                  </Button>
+                )}
+              </Empty>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/app/users/dashboard/third-party/vendors/[id]/edit/page.tsx
+++ b/app/users/dashboard/third-party/vendors/[id]/edit/page.tsx
@@ -1,9 +1,19 @@
 'use client';
 
 import { use } from 'react';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Building2 } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/shadcn/button';
+import { routes } from '@/nav';
 import { useVendor } from '@/hooks/vendors';
 import { VendorEditor } from '@/features/vendor/components/vendor-editor';
+import {
+  Empty,
+  EmptyErrorMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -23,7 +33,24 @@ export default function VendorEditPage({ params }: PageProps) {
     );
   }
 
-  if (!vendor) return null;
+  if (!vendor) {
+    return (
+      <Empty variant="default">
+        <EmptyErrorMedia>
+          <Building2 className="size-6" />
+        </EmptyErrorMedia>
+        <EmptyHeader>
+          <EmptyTitle>Vendor not found</EmptyTitle>
+          <EmptyDescription>
+            This vendor may have been deleted or does not exist.
+          </EmptyDescription>
+        </EmptyHeader>
+        <Button asChild>
+          <Link href={routes.thirdParty.vendors.href}>Back to Vendors</Link>
+        </Button>
+      </Empty>
+    );
+  }
 
   return <VendorEditor vendor={vendor} vendorId={vendorId} />;
 }

--- a/app/users/dashboard/third-party/vendors/[id]/page.tsx
+++ b/app/users/dashboard/third-party/vendors/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
   TabsTrigger,
 } from '@/components/shadcn/tabs';
 import { Edit, Building2, Loader2 } from 'lucide-react';
+import { PageHeader } from '@/components/common';
 import {
   Empty,
   EmptyErrorMedia,
@@ -98,27 +99,22 @@ export default function VendorDetailPage({ params }: PageProps) {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Header */}
-      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
-        <div>
-          <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            {vendor.name}
-          </h1>
-          <div className="mt-2 flex flex-wrap items-center gap-2">
+      <PageHeader
+        title={vendor.name}
+        actions={
+          <>
             <VendorStatusBadge status={vendor.status} />
             {vendor.type && (
               <Badge variant="outline">{getVendorTypeLabel(vendor.type)}</Badge>
             )}
-          </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <Button variant="outline" size="sm" asChild>
-            <Link href={routes.thirdParty.vendors.detail(vendor.id).edit}>
-              <Edit className="mr-2 h-4 w-4" /> Edit
-            </Link>
-          </Button>
-        </div>
-      </div>
+            <Button variant="outline" size="sm" asChild>
+              <Link href={routes.thirdParty.vendors.detail(vendor.id).edit}>
+                <Edit className="mr-2 h-4 w-4" /> Edit
+              </Link>
+            </Button>
+          </>
+        }
+      />
 
       <Tabs defaultValue="overview">
         <TabsList className="w-full">

--- a/app/users/dashboard/third-party/vendors/[id]/page.tsx
+++ b/app/users/dashboard/third-party/vendors/[id]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { use } from 'react';
-import { useRouter } from 'next/navigation';
 import { routes } from '@/nav';
 import Link from 'next/link';
 import { Button } from '@/components/shadcn/button';
@@ -12,7 +11,14 @@ import {
   TabsList,
   TabsTrigger,
 } from '@/components/shadcn/tabs';
-import { Edit, AlertCircle, Loader2 } from 'lucide-react';
+import { Edit, Building2, Loader2 } from 'lucide-react';
+import {
+  Empty,
+  EmptyErrorMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
 import {
   useVendor,
   useVendorContacts,
@@ -33,7 +39,6 @@ interface PageProps {
 
 export default function VendorDetailPage({ params }: PageProps) {
   const { id } = use(params);
-  const router = useRouter();
   const vendorId = Number(id);
 
   const isValidId = Number.isFinite(vendorId) && vendorId > 0;
@@ -45,16 +50,20 @@ export default function VendorDetailPage({ params }: PageProps) {
 
   if (!isValidId) {
     return (
-      <div className="flex min-h-[400px] flex-col items-center justify-center gap-4">
-        <AlertCircle className="h-12 w-12 text-red-500" />
-        <h2 className="text-xl font-semibold">Invalid Vendor ID</h2>
-        <p className="text-zinc-500">
-          &quot;{id}&quot; is not a valid vendor identifier.
-        </p>
-        <Button onClick={() => router.push(routes.thirdParty.vendors.href)}>
-          Back to Vendors
+      <Empty variant="default">
+        <EmptyErrorMedia>
+          <Building2 className="size-6" />
+        </EmptyErrorMedia>
+        <EmptyHeader>
+          <EmptyTitle>Invalid vendor</EmptyTitle>
+          <EmptyDescription>
+            &quot;{id}&quot; is not a valid vendor identifier.
+          </EmptyDescription>
+        </EmptyHeader>
+        <Button asChild>
+          <Link href={routes.thirdParty.vendors.href}>Back to Vendors</Link>
         </Button>
-      </div>
+      </Empty>
     );
   }
 
@@ -68,18 +77,22 @@ export default function VendorDetailPage({ params }: PageProps) {
 
   if (isError || !vendor) {
     return (
-      <div className="flex min-h-[400px] flex-col items-center justify-center gap-4">
-        <AlertCircle className="h-12 w-12 text-red-500" />
-        <h2 className="text-xl font-semibold">Vendor Not Found</h2>
-        <p className="text-zinc-500">
-          {isError && error instanceof Error
-            ? error.message
-            : `Vendor #${id} could not be found.`}
-        </p>
-        <Button onClick={() => router.push(routes.thirdParty.vendors.href)}>
-          Back to Vendors
+      <Empty variant="default">
+        <EmptyErrorMedia>
+          <Building2 className="size-6" />
+        </EmptyErrorMedia>
+        <EmptyHeader>
+          <EmptyTitle>Vendor not found</EmptyTitle>
+          <EmptyDescription>
+            {isError && error instanceof Error
+              ? error.message
+              : `Vendor #${id} could not be found.`}
+          </EmptyDescription>
+        </EmptyHeader>
+        <Button asChild>
+          <Link href={routes.thirdParty.vendors.href}>Back to Vendors</Link>
         </Button>
-      </div>
+      </Empty>
     );
   }
 

--- a/app/users/dashboard/third-party/vendors/new/page.tsx
+++ b/app/users/dashboard/third-party/vendors/new/page.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/shadcn/select';
 import { toast } from '@/lib/styles/toast-styles';
 import { Building2, Save, X } from 'lucide-react';
+import { PageHeader } from '@/components/common';
 import { useCreateVendor } from '@/hooks/vendors';
 import {
   VendorType,
@@ -75,14 +76,10 @@ export default function VendorNewPage() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-          Add New Vendor
-        </h1>
-        <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-          Fill in the basic details to add a new vendor
-        </p>
-      </div>
+      <PageHeader
+        title="Add New Vendor"
+        description="Fill in the basic details to add a new vendor"
+      />
 
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Company Information */}

--- a/features/vendor/components/vendor-banking-tab.tsx
+++ b/features/vendor/components/vendor-banking-tab.tsx
@@ -32,6 +32,13 @@ import {
 } from '@/components/shadcn/alert-dialog';
 import { CreditCard, Edit, Landmark, Plus, Star, Trash2 } from 'lucide-react';
 import {
+  Empty,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
+import {
   useVendorBankAccounts,
   useAddVendorBankAccount,
   useUpdateVendorBankAccount,
@@ -108,9 +115,17 @@ export function VendorBankingTab({ vendorId }: VendorBankingTabProps) {
         </CardHeader>
         <CardContent>
           {bankAccounts.length === 0 ? (
-            <p className="py-6 text-center text-sm text-zinc-400">
-              No bank accounts added yet.
-            </p>
+            <Empty variant="inline">
+              <EmptyMedia variant="icon">
+                <Landmark className="size-6" />
+              </EmptyMedia>
+              <EmptyHeader>
+                <EmptyTitle>No bank accounts yet</EmptyTitle>
+                <EmptyDescription>
+                  Add a bank account for this vendor.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
           ) : (
             <div className="space-y-3">
               {bankAccounts.map((b) => (

--- a/features/vendor/components/vendor-contacts-tab.tsx
+++ b/features/vendor/components/vendor-contacts-tab.tsx
@@ -31,6 +31,13 @@ import {
   AlertDialogTitle,
 } from '@/components/shadcn/alert-dialog';
 import { Edit, Mail, Phone, Plus, Star, Trash2 } from 'lucide-react';
+import {
+  Empty,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
 import { PhoneDisplay, PhoneInput } from '@/components/shadcn/phone-input';
 import {
   useVendorContacts,
@@ -107,9 +114,17 @@ export function VendorContactsTab({ vendorId }: VendorContactsTabProps) {
         </CardHeader>
         <CardContent>
           {contacts.length === 0 ? (
-            <p className="py-6 text-center text-sm text-zinc-400">
-              No contacts yet. Add a contact person for this vendor.
-            </p>
+            <Empty variant="inline">
+              <EmptyMedia variant="icon">
+                <Phone className="size-6" />
+              </EmptyMedia>
+              <EmptyHeader>
+                <EmptyTitle>No contacts yet</EmptyTitle>
+                <EmptyDescription>
+                  Add a contact person for this vendor.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
           ) : (
             <div className="space-y-3">
               {contacts.map((c) => (

--- a/features/vendor/components/vendor-editor.tsx
+++ b/features/vendor/components/vendor-editor.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/shadcn/select';
 import { toast } from '@/lib/styles/toast-styles';
 import { Building2, Save, X } from 'lucide-react';
+import { PageHeader } from '@/components/common';
 import { useUpdateVendor } from '@/hooks/vendors';
 import {
   VendorType,
@@ -83,14 +84,10 @@ export function VendorEditor({ vendor, vendorId }: VendorEditorProps) {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-          Edit Vendor
-        </h1>
-        <p className="mt-1 text-zinc-600 dark:text-zinc-400">
-          Update vendor information{form.name ? ` for ${form.name}` : ''}
-        </p>
-      </div>
+      <PageHeader
+        title="Edit Vendor"
+        description={`Update vendor information${form.name ? ` for ${form.name}` : ''}`}
+      />
 
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Company Information */}

--- a/features/vendor/components/vendor-table.tsx
+++ b/features/vendor/components/vendor-table.tsx
@@ -19,6 +19,14 @@ import { getVendorTypeLabel } from '@/types/vendor';
 import type { Vendor } from '@/types/vendor';
 import { VendorAvatar } from './vendor-avatar';
 import { VendorStatusBadge } from './vendor-status-badge';
+import {
+  Empty,
+  EmptyErrorMedia,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
 
 interface VendorTableProps {
   vendors: Vendor[];
@@ -47,26 +55,34 @@ export function VendorTable({
 
   if (isLoading) {
     return (
-      <div className="flex justify-center py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
-      </div>
+      <Card>
+        <CardContent className="flex justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
+        </CardContent>
+      </Card>
     );
   }
 
   if (isError) {
     return (
       <Card>
-        <CardContent className="py-12 text-center">
-          <Building2 className="mx-auto mb-4 h-12 w-12 text-red-400" />
-          <h3 className="mb-2 text-lg font-medium">Failed to load vendors</h3>
-          <p className="text-muted-foreground mb-4 text-sm">
-            {error instanceof Error
-              ? error.message
-              : 'An unexpected error occurred.'}
-          </p>
-          <Button variant="outline" onClick={onRetry}>
-            Retry
-          </Button>
+        <CardContent className="py-12">
+          <Empty variant="default">
+            <EmptyErrorMedia>
+              <Building2 className="size-6" />
+            </EmptyErrorMedia>
+            <EmptyHeader>
+              <EmptyTitle>Failed to load vendors</EmptyTitle>
+              <EmptyDescription>
+                {error instanceof Error
+                  ? error.message
+                  : 'An unexpected error occurred.'}
+              </EmptyDescription>
+            </EmptyHeader>
+            <Button variant="outline" onClick={onRetry}>
+              Retry
+            </Button>
+          </Empty>
         </CardContent>
       </Card>
     );
@@ -75,14 +91,20 @@ export function VendorTable({
   if (vendors.length === 0) {
     return (
       <Card>
-        <CardContent className="py-12 text-center">
-          <Building2 className="mx-auto mb-4 h-12 w-12 text-zinc-400" />
-          <h3 className="mb-2 text-lg font-medium">No vendors found</h3>
-          <p className="text-muted-foreground mb-4 text-sm">
-            {hasFilters
-              ? 'Try adjusting your filters.'
-              : 'Add your first vendor to get started.'}
-          </p>
+        <CardContent className="py-12">
+          <Empty variant="default">
+            <EmptyMedia variant="icon">
+              <Building2 className="size-6" />
+            </EmptyMedia>
+            <EmptyHeader>
+              <EmptyTitle>No vendors found</EmptyTitle>
+              <EmptyDescription>
+                {hasFilters
+                  ? 'Try adjusting your filters.'
+                  : 'Add your first vendor to get started.'}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
         </CardContent>
       </Card>
     );

--- a/features/vendor/components/vendor-tax-tab.tsx
+++ b/features/vendor/components/vendor-tax-tab.tsx
@@ -38,6 +38,13 @@ import {
 } from '@/components/shadcn/select';
 import { Edit, FileText, Plus, Trash2 } from 'lucide-react';
 import {
+  Empty,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
+import {
   useVendorTaxIdentifiers,
   useAddVendorTaxIdentifier,
   useUpdateVendorTaxIdentifier,
@@ -114,9 +121,17 @@ export function VendorTaxTab({ vendorId }: VendorTaxTabProps) {
         </CardHeader>
         <CardContent>
           {taxIdentifiers.length === 0 ? (
-            <p className="py-6 text-center text-sm text-zinc-400">
-              No tax identifiers added yet.
-            </p>
+            <Empty variant="inline">
+              <EmptyMedia variant="icon">
+                <FileText className="size-6" />
+              </EmptyMedia>
+              <EmptyHeader>
+                <EmptyTitle>No tax identifiers yet</EmptyTitle>
+                <EmptyDescription>
+                  Add a GST, PAN, or other tax identifier.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
           ) : (
             <div className="space-y-3">
               {taxIdentifiers.map((t) => (


### PR DESCRIPTION
## Description

This PR focuses on the first two phases of the Third-Party module UI/UX update roadmap. The goal is to bring the Vendors, Labour, and Sub-contracts sub-modules into alignment with the application's established design language for feedback systems and page headers.

## Changes Made

### Phase 1 — Loading / Error / Empty State Standardization
- **Standardized Feedback**: Replaced ad-hoc loading spinners and error divs with the centralized `<Empty>` component system across all 9 pages.
- **Improved Fallbacks**: Implemented standardized not-found and load-error guards for detail and edit views in the Labour and Sub-contract modules.
- **Component Alignment**: Updated `VendorTable` and its related tabs (banking, contacts, tax) to utilize the `<Empty>` system for more professional and consistent data states.

### Phase 2 — Header Standardization
- **PageHeader Migration**: Migrated all 10 pages/feature-components to use the `<PageHeader>` component, successfully removing all raw `<h1>` div structures.
- **Layout Consistency**: Standardized page-level actions, descriptions, and spacing across the Labour, Sub-contracts, and Vendor sub-modules.
- **Code Cleanup**: Removed redundant back buttons and manual layout styling in favor of the centralized header pattern used throughout the dashboard.

## Sub-modules Impacted
- **Labour**: List, Detail, New, and Edit pages.
- **Sub-contracts**: List, Detail, New, and Edit pages.
- **Vendors**: List, Detail, New, and Edit pages, including shared feature components like `VendorEditor` and `VendorTable`.

## Testing
- **Visual Audit**: Manually verified header alignment and empty state rendering across all modified pages.
- **Responsive Check**: Confirmed that the new `<Empty>` state guards work correctly on both mobile and desktop viewports (specifically for the Labour and Sub-contract tables).

## Checklist
- [x] Phase 1: Loading/Error/Empty states standardized.
- [x] Phase 2: Header migration to `<PageHeader>` complete.
- [x] Code adheres to the established Third-Party UI/UX roadmap.
- [x] Documentation (`docs/third-party-ui-update-plan.md`) updated to reflect progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized empty-state messaging and "record not found" screens across Labour, Sub-Contract, and Vendor sections with improved navigation options.

* **Bug Fixes**
  * Fixed missing vendor/labour/contract handling with dedicated error states instead of fallback behaviors.

* **Style**
  * Unified page headers and empty states with consistent UI components for improved visual consistency across the dashboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tornotron/echno-web/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->