### PR TITLE
refactor(materials): overhaul dashboard layout with embedded charts, table, and sidebar

### DIFF
--- a/app/users/dashboard/resources/materials/page.tsx
+++ b/app/users/dashboard/resources/materials/page.tsx
@@ -5,8 +5,10 @@ import { PageHeader } from '@/components/common';
 import { useMaterials, useAllMaterialConsumptions } from '@/hooks/materials';
 import {
   MaterialsKpiStrip,
-  MaterialsChartsRow,
-  MaterialsInsightsRow,
+  MaterialsDashboardTable,
+  StockValueByMaterial,
+  LowStockAlert,
+  TopProjectsConsuming,
   RecentStockMovements,
 } from '@/features/materials/components';
 
@@ -39,12 +41,22 @@ export default function MaterialsPage() {
         description="Manage and track all materials in your inventory"
       />
 
-      {/* Full-width sections */}
-      <MaterialsKpiStrip materials={materials} />
-      <MaterialsChartsRow materials={materials} consumptions={consumptions} />
+      <MaterialsKpiStrip materials={materials} consumptions={consumptions} />
 
-      <MaterialsInsightsRow materials={materials} consumptions={consumptions} />
-      <RecentStockMovements consumptions={consumptions} />
+      <div className="flex flex-col gap-4 sm:gap-6 lg:flex-row lg:items-start">
+        {/* Main column */}
+        <div className="min-w-0 flex-1 space-y-4 sm:space-y-6">
+          <MaterialsDashboardTable materials={materials} />
+          <RecentStockMovements consumptions={consumptions} />
+        </div>
+
+        {/* Right sidebar */}
+        <div className="w-full shrink-0 space-y-4 lg:w-72 xl:w-80">
+          <StockValueByMaterial materials={materials} />
+          <LowStockAlert materials={materials} />
+          <TopProjectsConsuming consumptions={consumptions} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/features/materials/components/index.ts
+++ b/features/materials/components/index.ts
@@ -5,6 +5,10 @@ export * from './material-stock-by-location-tab';
 export { MaterialList } from './material-list';
 export { MaterialListItem } from './material-list-item';
 export { MaterialsKpiStrip } from './materials-kpi-strip';
-export { MaterialsChartsRow } from './materials-charts-row';
-export { MaterialsInsightsRow } from './materials-insights-row';
+export { MaterialsDashboardTable } from './materials-dashboard-table';
+export {
+  StockValueByMaterial,
+  LowStockAlert,
+  TopProjectsConsuming,
+} from './materials-insights-row';
 export { RecentStockMovements } from './recent-stock-movements';

--- a/features/materials/components/materials-dashboard-table.tsx
+++ b/features/materials/components/materials-dashboard-table.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Search, Package } from 'lucide-react';
+import {
+  Empty,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+} from '@/components/shadcn/empty';
+import { Badge } from '@/components/shadcn/badge';
+import { Checkbox } from '@/components/shadcn/checkbox';
+import { Card, CardContent, CardHeader } from '@/components/shadcn/card';
+import { Input } from '@/components/shadcn/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/shadcn/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/shadcn/table';
+import { Pagination } from '@/components/common';
+import { routes } from '@/nav';
+import type { Material } from '@/types/materials';
+
+const ITEMS_PER_PAGE_OPTIONS = ['5', '10', '20', '50'];
+
+export function MaterialsDashboardTable({
+  materials,
+}: {
+  materials: Material[];
+}) {
+  const router = useRouter();
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [unitFilter, setUnitFilter] = useState('all');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+
+  const unitOptions = useMemo(() => {
+    const units = [
+      ...new Set(materials.map((m) => m.unit).filter(Boolean)),
+    ].toSorted();
+    return units.map((u) => ({ value: u, label: u }));
+  }, [materials]);
+
+  const filtered = useMemo(() => {
+    const q = searchQuery.toLowerCase();
+    return materials.filter((m) => {
+      const matchesSearch =
+        !q ||
+        m.materialName.toLowerCase().includes(q) ||
+        (m.sku ?? '').toLowerCase().includes(q);
+      const matchesUnit =
+        unitFilter === 'all' ||
+        m.unit.toLowerCase() === unitFilter.toLowerCase();
+      return matchesSearch && matchesUnit;
+    });
+  }, [materials, searchQuery, unitFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / itemsPerPage));
+  const safePage = Math.min(currentPage, totalPages);
+  const startIndex = (safePage - 1) * itemsPerPage;
+  const paginated = filtered.slice(startIndex, startIndex + itemsPerPage);
+
+  const isAllSelected =
+    paginated.length > 0 && paginated.every((m) => selectedIds.includes(m.id));
+
+  const handleSelectAll = (checked: boolean) => {
+    setSelectedIds(checked ? paginated.map((m) => m.id) : []);
+  };
+
+  const handleSelectOne = (id: number, checked: boolean) => {
+    setSelectedIds((prev) =>
+      checked ? [...prev, id] : prev.filter((x) => x !== id)
+    );
+  };
+
+  const handleSearch = (value: string) => {
+    setSearchQuery(value);
+    setCurrentPage(1);
+  };
+
+  const handleUnitChange = (value: string) => {
+    setUnitFilter(value);
+    setCurrentPage(1);
+  };
+
+  const handleItemsPerPage = (value: string) => {
+    setItemsPerPage(Number(value));
+    setCurrentPage(1);
+  };
+
+  return (
+    <Card className="gap-0 py-0">
+      <CardHeader className="flex flex-row items-center gap-3 border-b px-4 py-6">
+        <div className="relative w-full max-w-xs">
+          <Search className="absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-zinc-400" />
+          <Input
+            value={searchQuery}
+            onChange={(e) => handleSearch(e.target.value)}
+            placeholder="Search by name or SKU…"
+            className="h-8 pl-8 text-sm"
+          />
+        </div>
+
+        <Select value={unitFilter} onValueChange={handleUnitChange}>
+          <SelectTrigger className="h-8 w-[120px] text-xs">
+            <SelectValue placeholder="All Units" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Units</SelectItem>
+            {unitOptions.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="ml-auto flex items-center gap-2 border-l pl-3">
+          <span className="text-xs whitespace-nowrap text-zinc-500">
+            Rows per page
+          </span>
+          <Select
+            value={String(itemsPerPage)}
+            onValueChange={handleItemsPerPage}
+          >
+            <SelectTrigger className="h-8 w-[60px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ITEMS_PER_PAGE_OPTIONS.map((n) => (
+                <SelectItem key={n} value={n}>
+                  {n}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+
+      <CardContent className="overflow-x-auto p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-12 pl-5">
+                <Checkbox
+                  checked={isAllSelected}
+                  onCheckedChange={handleSelectAll}
+                  aria-label="Select all"
+                />
+              </TableHead>
+              <TableHead>Material</TableHead>
+              <TableHead>Unit</TableHead>
+              <TableHead className="text-right">Stock</TableHead>
+              <TableHead className="text-right">Reorder At</TableHead>
+              <TableHead className="text-right">Value</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {paginated.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6}>
+                  <Empty variant="inline">
+                    <EmptyMedia variant="icon">
+                      <Package className="size-6" />
+                    </EmptyMedia>
+                    <EmptyHeader>
+                      <EmptyTitle>No materials found</EmptyTitle>
+                      <EmptyDescription>
+                        {searchQuery || unitFilter !== 'all'
+                          ? 'Try adjusting your search or filters.'
+                          : 'Get started by adding your first material.'}
+                      </EmptyDescription>
+                    </EmptyHeader>
+                  </Empty>
+                </TableCell>
+              </TableRow>
+            )}
+            {paginated.map((m) => {
+              const isLow =
+                m.reorderLevel !== undefined &&
+                m.currentStock !== undefined &&
+                m.currentStock <= m.reorderLevel;
+              return (
+                <TableRow
+                  key={m.id}
+                  className="hover:bg-muted/50 cursor-pointer"
+                  onClick={() =>
+                    router.push(routes.resources.materials.detail(m.id).href)
+                  }
+                >
+                  <TableCell
+                    className="pl-5"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <Checkbox
+                      checked={selectedIds.includes(m.id)}
+                      onCheckedChange={(checked) =>
+                        handleSelectOne(m.id, checked as boolean)
+                      }
+                      aria-label={`Select ${m.materialName}`}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <p className="font-medium text-zinc-900 dark:text-zinc-100">
+                      {m.materialName}
+                    </p>
+                    {m.sku && <p className="text-xs text-zinc-500">{m.sku}</p>}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline">{m.unit}</Badge>
+                  </TableCell>
+                  <TableCell
+                    className={`text-right font-medium tabular-nums ${
+                      isLow
+                        ? 'text-red-600 dark:text-red-400'
+                        : 'text-zinc-700 dark:text-zinc-300'
+                    }`}
+                  >
+                    {m.currentStock ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-right text-zinc-500 tabular-nums dark:text-zinc-400">
+                    {m.reorderLevel ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-right text-zinc-700 tabular-nums dark:text-zinc-300">
+                    {m.stockValue === undefined
+                      ? '—'
+                      : `₹${m.stockValue.toLocaleString('en-IN')}`}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+
+      <div className="flex items-center justify-between border-t px-4 py-2">
+        <span className="text-xs text-zinc-500 dark:text-zinc-400">
+          Showing {filtered.length === 0 ? 0 : startIndex + 1}–
+          {Math.min(startIndex + itemsPerPage, filtered.length)} of{' '}
+          {filtered.length}
+        </span>
+        <Pagination
+          currentPage={safePage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/features/materials/components/materials-insights-row.tsx
+++ b/features/materials/components/materials-insights-row.tsx
@@ -15,20 +15,7 @@ import {
 import { routes } from '@/nav';
 import type { Material, MaterialConsumption } from '@/types/materials';
 
-interface MaterialsInsightsRowProps {
-  materials: Material[];
-  consumptions: MaterialConsumption[];
-}
-
-export function MaterialsInsightsRow({
-  materials,
-  consumptions,
-}: MaterialsInsightsRowProps) {
-  const [projectPeriod, setProjectPeriod] = useState<
-    'thisMonth' | 'lastMonth' | 'thisYear'
-  >('thisMonth');
-
-  // ── Stock value by material (top 5) ────────────────────────────────────────
+export function StockValueByMaterial({ materials }: { materials: Material[] }) {
   const stockValueData = useMemo(() => {
     const sorted = [...materials]
       .filter((m) => (m.stockValue ?? 0) > 0)
@@ -46,7 +33,61 @@ export function MaterialsInsightsRow({
     }));
   }, [materials]);
 
-  // ── Low stock ──────────────────────────────────────────────────────────────
+  return (
+    <Card>
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          Stock Value by Material
+        </p>
+        <Link
+          href={routes.resources.materials.allMaterials}
+          className="flex items-center gap-0.5 text-xs text-blue-600 hover:underline dark:text-blue-400"
+        >
+          View report
+          <ArrowUpRight className="h-3 w-3" />
+        </Link>
+      </div>
+      <CardContent className="p-4">
+        {stockValueData.length === 0 ? (
+          <p className="py-4 text-center text-sm text-zinc-500 dark:text-zinc-400">
+            No stock value data.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {stockValueData.map((d) => (
+              <div key={d.id} className="space-y-1">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="truncate text-zinc-700 dark:text-zinc-300">
+                    {d.name}
+                  </span>
+                  <div className="ml-2 flex shrink-0 items-center gap-2">
+                    <span className="text-zinc-500 dark:text-zinc-400">
+                      {d.pct}%
+                    </span>
+                    <span className="font-semibold text-zinc-900 tabular-nums dark:text-zinc-100">
+                      ₹{d.value.toLocaleString('en-IN')}
+                    </span>
+                  </div>
+                </div>
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                  <div
+                    className="h-full rounded-full transition-all"
+                    style={{
+                      width: `${d.barPct}%`,
+                      backgroundColor: d.color,
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function LowStockAlert({ materials }: { materials: Material[] }) {
   const lowStockItems = useMemo(
     () =>
       materials
@@ -65,7 +106,66 @@ export function MaterialsInsightsRow({
     [materials]
   );
 
-  // ── Top projects by consumption ────────────────────────────────────────────
+  return (
+    <Card>
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-orange-500 dark:text-orange-400" />
+          <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            Low Stock Alert
+          </p>
+        </div>
+        <Link
+          href={routes.resources.materials.allMaterials}
+          className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+        >
+          View all
+        </Link>
+      </div>
+      <CardContent className="p-4">
+        {lowStockItems.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-3 text-center">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/30">
+              <CheckCircle2 className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+            </div>
+            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+              All materials are well stocked.
+            </p>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Great job!
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2.5">
+            {lowStockItems.map((m) => (
+              <div
+                key={m.id}
+                className="flex items-center justify-between text-sm"
+              >
+                <span className="truncate text-zinc-700 dark:text-zinc-300">
+                  {m.materialName}
+                </span>
+                <span className="ml-2 shrink-0 text-xs font-medium text-red-600 dark:text-red-400">
+                  {m.currentStock} / {m.reorderLevel} {m.unit}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function TopProjectsConsuming({
+  consumptions,
+}: {
+  consumptions: MaterialConsumption[];
+}) {
+  const [projectPeriod, setProjectPeriod] = useState<
+    'thisMonth' | 'lastMonth' | 'thisYear'
+  >('thisMonth');
+
   const projectData = useMemo(() => {
     const now = new Date();
     const filtered = consumptions.filter((c) => {
@@ -107,171 +207,67 @@ export function MaterialsInsightsRow({
   }, [consumptions, projectPeriod]);
 
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-      {/* Stock Value by Material */}
-      <Card>
-        <div className="flex items-center justify-between border-b px-4 py-3">
-          <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-            Stock Value by Material
+    <Card>
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          Top Projects Consuming
+        </p>
+        <Select
+          value={projectPeriod}
+          onValueChange={(v) =>
+            setProjectPeriod(v as 'thisMonth' | 'lastMonth' | 'thisYear')
+          }
+        >
+          <SelectTrigger className="h-7 w-32 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="thisMonth">This Month</SelectItem>
+            <SelectItem value="lastMonth">Last Month</SelectItem>
+            <SelectItem value="thisYear">This Year</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <CardContent className="p-4">
+        {projectData.length === 0 ? (
+          <p className="py-2 text-center text-sm text-zinc-500 dark:text-zinc-400">
+            No consumption data for this period.
           </p>
-          <Link
-            href={routes.resources.materials.allMaterials}
-            className="flex items-center gap-0.5 text-xs text-blue-600 hover:underline dark:text-blue-400"
-          >
-            View report
-            <ArrowUpRight className="h-3 w-3" />
-          </Link>
-        </div>
-        <CardContent className="p-4">
-          {stockValueData.length === 0 ? (
-            <p className="py-4 text-center text-sm text-zinc-500 dark:text-zinc-400">
-              No stock value data.
-            </p>
-          ) : (
-            <div className="space-y-3">
-              {stockValueData.map((d) => (
-                <div key={d.id} className="space-y-1">
-                  <div className="flex items-center justify-between text-xs">
-                    <span className="truncate text-zinc-700 dark:text-zinc-300">
-                      {d.name}
-                    </span>
-                    <div className="ml-2 flex shrink-0 items-center gap-2">
-                      <span className="text-zinc-500 dark:text-zinc-400">
-                        {d.pct}%
-                      </span>
-                      <span className="font-semibold text-zinc-900 tabular-nums dark:text-zinc-100">
-                        ₹{d.value.toLocaleString('en-IN')}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
-                    <div
-                      className="h-full rounded-full transition-all"
-                      style={{
-                        width: `${d.barPct}%`,
-                        backgroundColor: d.color,
-                      }}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Low Stock Alert */}
-      <Card>
-        <div className="flex items-center justify-between border-b px-4 py-3">
-          <div className="flex items-center gap-2">
-            <AlertTriangle className="h-4 w-4 text-orange-500 dark:text-orange-400" />
-            <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-              Low Stock Alert
-            </p>
-          </div>
-          <Link
-            href={routes.resources.materials.allMaterials}
-            className="text-xs text-blue-600 hover:underline dark:text-blue-400"
-          >
-            View all
-          </Link>
-        </div>
-        <CardContent className="p-4">
-          {lowStockItems.length === 0 ? (
-            <div className="flex flex-col items-center gap-2 py-3 text-center">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/30">
-                <CheckCircle2 className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                All materials are well stocked.
-              </p>
-              <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                Great job!
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-2.5">
-              {lowStockItems.map((m) => (
-                <div
-                  key={m.id}
-                  className="flex items-center justify-between text-sm"
-                >
+        ) : (
+          <div className="space-y-3">
+            {projectData.map((p) => (
+              <div key={p.name} className="space-y-1">
+                <div className="flex items-center justify-between text-xs">
                   <span className="truncate text-zinc-700 dark:text-zinc-300">
-                    {m.materialName}
+                    {p.name}
                   </span>
-                  <span className="ml-2 shrink-0 text-xs font-medium text-red-600 dark:text-red-400">
-                    {m.currentStock} / {m.reorderLevel} {m.unit}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Top Projects Consuming Materials */}
-      <Card>
-        <div className="flex items-center justify-between border-b px-4 py-3">
-          <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-            Top Projects Consuming
-          </p>
-          <Select
-            value={projectPeriod}
-            onValueChange={(v) =>
-              setProjectPeriod(v as 'thisMonth' | 'lastMonth' | 'thisYear')
-            }
-          >
-            <SelectTrigger className="h-7 w-28 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="thisMonth">This Month</SelectItem>
-              <SelectItem value="lastMonth">Last Month</SelectItem>
-              <SelectItem value="thisYear">This Year</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <CardContent className="p-4">
-          {projectData.length === 0 ? (
-            <p className="py-2 text-center text-sm text-zinc-500 dark:text-zinc-400">
-              No consumption data for this period.
-            </p>
-          ) : (
-            <div className="space-y-3">
-              {projectData.map((p) => (
-                <div key={p.name} className="space-y-1">
-                  <div className="flex items-center justify-between text-xs">
-                    <span className="truncate text-zinc-700 dark:text-zinc-300">
-                      {p.name}
+                  <div className="ml-2 flex shrink-0 items-center gap-2">
+                    <span className="text-zinc-500 dark:text-zinc-400">
+                      {p.pct}%
                     </span>
-                    <div className="ml-2 flex shrink-0 items-center gap-2">
-                      <span className="text-zinc-500 dark:text-zinc-400">
-                        {p.pct}%
-                      </span>
-                      <span className="font-semibold text-zinc-900 tabular-nums dark:text-zinc-100">
-                        {p.qty.toLocaleString()}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
-                    <div
-                      className="h-full rounded-full transition-all"
-                      style={{ width: `${p.pct}%`, backgroundColor: p.color }}
-                    />
+                    <span className="font-semibold text-zinc-900 tabular-nums dark:text-zinc-100">
+                      {p.qty.toLocaleString()}
+                    </span>
                   </div>
                 </div>
-              ))}
-            </div>
-          )}
-          <Link
-            href={routes.portfolio.projects.href}
-            className="mt-4 flex items-center gap-0.5 text-xs text-blue-600 hover:underline dark:text-blue-400"
-          >
-            View all projects
-            <ArrowUpRight className="h-3 w-3" />
-          </Link>
-        </CardContent>
-      </Card>
-    </div>
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                  <div
+                    className="h-full rounded-full transition-all"
+                    style={{ width: `${p.pct}%`, backgroundColor: p.color }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        <Link
+          href={routes.portfolio.projects.href}
+          className="mt-4 flex items-center gap-0.5 text-xs text-blue-600 hover:underline dark:text-blue-400"
+        >
+          View all projects
+          <ArrowUpRight className="h-3 w-3" />
+        </Link>
+      </CardContent>
+    </Card>
   );
 }

--- a/features/materials/components/materials-kpi-strip.tsx
+++ b/features/materials/components/materials-kpi-strip.tsx
@@ -1,18 +1,29 @@
-import Link from 'next/link';
+'use client';
+
+import { useMemo } from 'react';
+import { Layers, WarehouseIcon, Ruler } from 'lucide-react';
 import {
-  Layers,
-  WarehouseIcon,
-  Ruler,
-  ChevronRight,
-  ClipboardList,
-  ShoppingCart,
-} from 'lucide-react';
+  PieChart,
+  Pie,
+  Cell,
+  LineChart,
+  Line,
+  XAxis,
+  CartesianGrid,
+} from 'recharts';
 import { Card } from '@/components/shadcn/card';
-import { routes } from '@/nav';
-import type { Material } from '@/types/materials';
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  CHART_PALETTE,
+  type ChartConfig,
+} from '@/components/shadcn/chart';
+import type { Material, MaterialConsumption } from '@/types/materials';
 
 interface MaterialsKpiStripProps {
   materials: Material[];
+  consumptions: MaterialConsumption[];
 }
 
 function formatStockValue(v: number): string {
@@ -22,37 +33,70 @@ function formatStockValue(v: number): string {
   return `₹${v.toLocaleString('en-IN')}`;
 }
 
-const QUICK_ACTIONS = [
-  {
-    icon: Layers,
-    label: 'All Materials',
-    href: routes.resources.materials.allMaterials,
-  },
-  {
-    icon: ClipboardList,
-    label: 'Create Indent',
-    href: routes.resources.indents.new,
-  },
-  {
-    icon: ShoppingCart,
-    label: 'Create PO',
-    href: routes.resources.purchaseOrders.new,
-  },
-];
+function buildMonthlyTrend(consumptions: MaterialConsumption[], count: number) {
+  const now = new Date();
+  return Array.from({ length: count }, (_, i) => {
+    const d = new Date(now.getFullYear(), now.getMonth() - (count - 1 - i), 1);
+    const year = d.getFullYear();
+    const month = d.getMonth();
+    const value = consumptions
+      .filter((c) => {
+        const cd = new Date(c.consumptionDate);
+        return cd.getFullYear() === year && cd.getMonth() === month;
+      })
+      .reduce((sum, c) => sum + c.quantity, 0);
+    return { month: d.toLocaleDateString('en-US', { month: 'short' }), value };
+  });
+}
 
-export function MaterialsKpiStrip({ materials }: MaterialsKpiStripProps) {
+export function MaterialsKpiStrip({
+  materials,
+  consumptions,
+}: MaterialsKpiStripProps) {
   const totalMaterials = materials.length;
   const totalStockValue = materials.reduce(
     (s, m) => s + (m.stockValue ?? 0),
     0
   );
-
   const uniqueUnits = new Set(materials.map((m) => m.unit).filter(Boolean))
     .size;
 
+  const compositionData = useMemo(() => {
+    const groups = new Map<string, number>();
+    for (const m of materials) {
+      groups.set(m.unit, (groups.get(m.unit) ?? 0) + 1);
+    }
+    const total = materials.length;
+    return [...groups.entries()]
+      .map(([name, count], i) => ({
+        name,
+        value: count,
+        pct: total > 0 ? Math.round((count / total) * 100) : 0,
+        fill: CHART_PALETTE[i % CHART_PALETTE.length],
+      }))
+      .toSorted((a, b) => b.value - a.value);
+  }, [materials]);
+
+  const compositionConfig: ChartConfig = useMemo(
+    () =>
+      Object.fromEntries(
+        compositionData.map((d) => [d.name, { label: d.name, color: d.fill }])
+      ),
+    [compositionData]
+  );
+
+  const trendData = useMemo(
+    () => buildMonthlyTrend(consumptions, 6),
+    [consumptions]
+  );
+
+  const trendConfig: ChartConfig = {
+    value: { label: 'Qty', color: CHART_PALETTE[0] },
+  };
+
   return (
     <Card className="gap-0 p-6">
-      <div className="sm:divide-border grid grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-0 sm:divide-x">
+      <div className="sm:divide-border grid grid-cols-2 gap-3 sm:grid-cols-5 sm:gap-0 sm:divide-x">
         {/* Total Materials */}
         <div className="flex flex-col gap-1 rounded-lg p-3 sm:rounded-none sm:pr-6">
           <p className="text-xs text-zinc-500 dark:text-zinc-400">
@@ -107,26 +151,95 @@ export function MaterialsKpiStrip({ materials }: MaterialsKpiStripProps) {
           </p>
         </div>
 
-        {/* Quick Actions */}
-        <div className="col-span-2 rounded-lg p-3 sm:col-span-1 sm:rounded-none sm:pl-6">
-          <p className="mb-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">
-            Quick Actions
+        {/* Composition by Unit */}
+        <div className="flex flex-col gap-1 rounded-lg p-3 sm:rounded-none sm:px-6">
+          <p className="text-xs font-medium tracking-wider text-zinc-500 uppercase dark:text-zinc-400">
+            Composition by Unit
           </p>
-          <div className="space-y-0.5">
-            {QUICK_ACTIONS.map((action) => (
-              <Link
-                key={action.label}
-                href={action.href}
-                className="group hover:bg-muted/60 flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors"
+          {compositionData.length === 0 ? (
+            <p className="py-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
+              No data
+            </p>
+          ) : (
+            <div className="flex min-h-0 flex-1 items-center gap-3">
+              <ChartContainer
+                config={compositionConfig}
+                className="h-[60px] w-[60px] shrink-0"
               >
-                <action.icon className="size-3.5 shrink-0 text-zinc-400 group-hover:text-zinc-900 dark:group-hover:text-zinc-100" />
-                <span className="flex-1 text-xs text-zinc-700 dark:text-zinc-300">
-                  {action.label}
-                </span>
-                <ChevronRight className="size-3 text-zinc-400" />
-              </Link>
-            ))}
-          </div>
+                <PieChart>
+                  <ChartTooltip
+                    cursor={false}
+                    content={<ChartTooltipContent hideLabel nameKey="name" />}
+                  />
+                  <Pie
+                    data={compositionData}
+                    dataKey="value"
+                    nameKey="name"
+                    innerRadius={14}
+                    outerRadius={26}
+                    strokeWidth={0}
+                  >
+                    {compositionData.map((d) => (
+                      <Cell key={d.name} fill={d.fill} />
+                    ))}
+                  </Pie>
+                </PieChart>
+              </ChartContainer>
+              <div className="flex-1 space-y-1 overflow-hidden">
+                {compositionData.slice(0, 3).map((d) => (
+                  <div
+                    key={d.name}
+                    className="flex items-center justify-between text-xs"
+                  >
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <div
+                        className="h-1.5 w-1.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: d.fill }}
+                      />
+                      <span className="truncate text-zinc-600 dark:text-zinc-400">
+                        {d.name}
+                      </span>
+                    </div>
+                    <span className="ml-1 shrink-0 font-medium text-zinc-500 dark:text-zinc-400">
+                      {d.pct}%
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Trend (Consumption) */}
+        <div className="col-span-2 flex flex-col gap-1 rounded-lg p-3 sm:col-span-1 sm:rounded-none sm:pl-6">
+          <p className="text-xs font-medium tracking-wider text-zinc-500 uppercase dark:text-zinc-400">
+            Trend (Consumption)
+          </p>
+          <ChartContainer config={trendConfig} className="h-[60px] w-full">
+            <LineChart data={trendData} margin={{ left: 0, right: 4 }}>
+              <CartesianGrid
+                vertical={false}
+                strokeDasharray="3 3"
+                stroke="hsl(var(--border))"
+              />
+              <XAxis
+                dataKey="month"
+                tickLine={false}
+                axisLine={false}
+                tick={{ fontSize: 8 }}
+                tickMargin={2}
+              />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Line
+                type="monotone"
+                dataKey="value"
+                stroke={CHART_PALETTE[0]}
+                strokeWidth={1.5}
+                dot={false}
+                activeDot={{ r: 3 }}
+              />
+            </LineChart>
+          </ChartContainer>
         </div>
       </div>
     </Card>


### PR DESCRIPTION
## Description

This PR replaces the flat, stacked layout of the Materials dashboard with a structured two-column design. Charts that previously occupied a dedicated full-width row are now embedded directly in the KPI strip. The three insight panels move to a fixed right sidebar. A new data table — built to match the existing employee and leave table conventions — replaces the old card-based material list on the dashboard.

## Changes Made

### `MaterialsKpiStrip` — Charts Embedded (5-Column Grid)
- Removed the **Quick Actions** column.
- Added **Composition by Unit**: compact donut chart (`PieChart` + `Pie` + per-slice `Cell`, `innerRadius 14 / outerRadius 26`) with a top-3 unit legend beside it.
- Added **Trend (Consumption)**: compact 6-month sparkline (`LineChart`) with month labels.
- Grid expanded from `sm:grid-cols-4` to `sm:grid-cols-5`. `consumptions` added as a required prop.
- `MaterialsChartsRow` removed from the page (its charts are now embedded in the strip).

### Two-Column Page Layout
- **Main column** (`flex-1`): `MaterialsDashboardTable` stacked above `RecentStockMovements`.
- **Right sidebar** (`lg:w-72 xl:w-80`): `StockValueByMaterial`, `LowStockAlert`, and `TopProjectsConsuming` stacked vertically.
- Collapses to a single column below the `lg` breakpoint.

### `MaterialsDashboardTable` (new component)
Matches the employee / leave table UI pattern exactly:
- `Card gap-0 py-0` + `CardHeader` toolbar: `h-8` search input, unit filter select, rows-per-page select (separated by `border-l` divider).
- shadcn `Table` / `TableHeader` / `TableBody` / `TableRow` / `TableHead` / `TableCell`.
- Per-row `Checkbox` with select-all; `e.stopPropagation()` on the checkbox cell.
- `useRouter` row-click navigation to the material detail page.
- `Empty` / `EmptyMedia` / `EmptyHeader` empty state.
- Stock column turns red when a material is at or below its reorder level.

### `MaterialsInsightsRow` — Decomposed
- The three-column grid wrapper removed.
- Each panel extracted as a standalone named export:
  - `StockValueByMaterial({ materials })`
  - `LowStockAlert({ materials })`
  - `TopProjectsConsuming({ consumptions })`
- `index.ts` updated to export all three individually.

## Files Changed
| File | Change |
|------|--------|
| `app/users/dashboard/resources/materials/page.tsx` | New two-column layout; updated imports |
| `features/materials/components/materials-kpi-strip.tsx` | 5-col grid; donut + sparkline charts embedded |
| `features/materials/components/materials-dashboard-table.tsx` | New — shadcn table pattern |
| `features/materials/components/materials-insights-row.tsx` | Decomposed into 3 standalone card components |
| `features/materials/components/index.ts` | Updated exports |

## Testing
- Verified search, unit filter, and rows-per-page controls in the new table.
- Confirmed low-stock row highlighting and click-through navigation.
- Checked the donut chart tooltip and sparkline render correctly with real data.
- Validated the period selector in *Top Projects Consuming* filters correctly.
- Verified responsive stacking on narrow viewports (sidebar moves below main column).

## Checklist
- [x] KPI strip embeds Composition by Unit (donut) and Trend (sparkline).
- [x] `MaterialsChartsRow` removed from the page.
- [x] Dashboard table follows employee/leave table UI pattern.
- [x] Insight panels extracted as individually importable components.
- [x] Two-column layout collapses gracefully on mobile.
- [x] TypeScript passes with no errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added materials dashboard table with search (by name/SKU), unit filtering, pagination, and row selection capabilities
- Low stock items are now highlighted in the materials table for quick visibility
- Reorganized dashboard layout into a two-column structure for improved information hierarchy
- New pie and line charts in the KPI section displaying material composition and consumption trends

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tornotron/echno-web/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->